### PR TITLE
1.1.4

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "burla"
-version = "1.1.3"
+version = "1.1.4"
 description = "Scale your program across 1000s of computers with one line of code."
 authors = ["Jake Zuliani <jake@burla.dev>"]
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -3,7 +3,7 @@ from fire import Fire
 
 
 # needed so main_service can associate a client version with a request
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 from burla._auth import login

--- a/main_service/pyproject.toml
+++ b/main_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "main_service"
-version = "1.1.3"
+version = "1.1.4"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>, Joseph Perry <joe@burla.dev>"]
 packages = [{include = "main_service", from = "src"}]

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -21,7 +21,7 @@ from jinja2 import Environment, FileSystemLoader
 os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
-CURRENT_BURLA_VERSION = "1.1.3"
+CURRENT_BURLA_VERSION = "1.1.4"
 
 # This is the only possible alternative "mode".
 # In this mode everything runs locally in docker containers.

--- a/node_service/Dockerfile
+++ b/node_service/Dockerfile
@@ -47,10 +47,10 @@ RUN ln -sf /usr/local/bin/python3.13 /usr/bin/python
 
 
 # Install latest node_service and pip install packages now to make node starts faster
-RUN git clone --depth 1 --branch 1.1.3 https://github.com/Burla-Cloud/burla.git --no-checkout
+RUN git clone --depth 1 --branch 1.1.4 https://github.com/Burla-Cloud/burla.git --no-checkout
 WORKDIR burla
 RUN git sparse-checkout init --cone && \
     git sparse-checkout set node_service && \
-    git checkout 1.1.3
+    git checkout 1.1.4
 WORKDIR node_service
 RUN python -m pip install --break-system-packages -e .

--- a/node_service/pyproject.toml
+++ b/node_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node-service"
-version = "1.1.3"
+version = "1.1.4"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "node_service", from = "src"}]

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -22,7 +22,7 @@ from starlette.datastructures import UploadFile
 from google.cloud import logging, secretmanager, firestore
 from google.cloud.compute_v1 import InstancesClient
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 CREDENTIALS, PROJECT_ID = google.auth.default()
 BURLA_BACKEND_URL = "https://backend.burla.dev"
 

--- a/worker_service/pyproject.toml
+++ b/worker_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "worker_service"
-version = "1.1.3"
+version = "1.1.4"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "worker_service", from = "src"}]


### PR DESCRIPTION
**Burla Release 1.1.4**
_"The simplest way to orchestrate parallel python"_

- Job progress indicator in dashboard is smoother and more reliable (https://github.com/Burla-Cloud/burla/pull/73)

To update run `pip install burla==1.1.4`, then run `burla install`