### PR TITLE
1.2.5

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "burla"
-version = "1.2.4"
+version = "1.2.5"
 description = "The simplest way to run Python on lot's of computers."
 authors = ["Jake Zuliani <jake@burla.dev>"]
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -4,7 +4,7 @@ from fire import Fire
 from appdirs import user_config_dir
 
 # needed so main_service can associate a client version with a request
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,27 +1,3 @@
-# from time import sleep
-# from burla import remote_parallel_map
-
-# my_inputs = list(range(1000))
-
-
-# def my_function(my_input):
-#     sleep(1)
-#     print(f"Running Input #{my_input} on it's own separate computer in the cloud!")
-
-
-# remote_parallel_map(my_function, my_inputs)
-
-
-from burla import remote_parallel_map
-
-
-def my_function(x):
-    print(f"Running on a remote computer in the cloud! #{x}")
-
-
-remote_parallel_map(my_function, list(range(1000)))
-
-
 from burla import remote_parallel_map
 
 

--- a/examples/vector_embeddings/pyproject.toml
+++ b/examples/vector_embeddings/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.12"
 google-cloud-compute = "^1.33.0"
 google-auth = "^2.40.3"
 google-cloud-storage = "^3.2.0"
-burla = "^1.2.4"
+burla = "^1.2.5"
 
 
 [build-system]

--- a/main_service/frontend/src/components/ClusterStatusCard.tsx
+++ b/main_service/frontend/src/components/ClusterStatusCard.tsx
@@ -31,7 +31,7 @@ export const ClusterStatusCard = ({
     const showStats = hasResources;
     const summaryParts = [`${parallelism} CPUs`, `${totalRam} RAM`] as string[];
     if (gpuCount && gpuCount > 0) summaryParts.push(`${gpuCount} GPUs`);
-    const summary = summaryParts.join(" · ");
+    const summary = summaryParts.join("   ");
 
     return (
         <Card className="inline-block">

--- a/main_service/frontend/src/components/NodesList.tsx
+++ b/main_service/frontend/src/components/NodesList.tsx
@@ -28,7 +28,7 @@ export const NodesList = ({ nodes }: NodesListProps) => {
 def my_function(x):
     print(f"Running on a remote computer in the cloud! #{x}")
 
-remote_parallel_map(my_function, [1, 2, 3, 4])`;
+remote_parallel_map(my_function, list(range(1000)))`;
 
     useEffect(() => {
         const isWelcomeHidden = localStorage.getItem("welcomeMessageHidden") === "true";

--- a/main_service/makefile
+++ b/main_service/makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 .SILENT:
 
-BURLA_VERSION = 1.2.4
+BURLA_VERSION = 1.2.5
 WEBSERVICE_NAME = burla-main-service
 PYTHON_MODULE_NAME = main_service
 

--- a/main_service/pyproject.toml
+++ b/main_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "main_service"
-version = "1.2.4"
+version = "1.2.5"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>, Joseph Perry <joe@burla.dev>"]
 packages = [{include = "main_service", from = "src"}]

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -21,7 +21,7 @@ from jinja2 import Environment, FileSystemLoader
 os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
-CURRENT_BURLA_VERSION = "1.2.4"
+CURRENT_BURLA_VERSION = "1.2.5"
 
 # This is the only possible alternative "mode".
 # In this mode everything runs locally in docker containers.

--- a/main_service/src/main_service/static/index.html
+++ b/main_service/src/main_service/static/index.html
@@ -10,7 +10,7 @@
         />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="apple-touch-icon" href="/favicon.png" />
-      <script type="module" crossorigin src="/assets/index-Ct9oDk9I.js"></script>
+      <script type="module" crossorigin src="/assets/index-BrNiLx0e.js"></script>
       <link rel="stylesheet" crossorigin href="/assets/index-6cxP9ZlT.css">
     </head>
 

--- a/node_service/Dockerfile
+++ b/node_service/Dockerfile
@@ -47,10 +47,10 @@ RUN ln -sf /usr/local/bin/python3.13 /usr/bin/python
 
 
 # Install latest node_service and pip install packages now to make node starts faster
-RUN git clone --depth 1 --branch 1.2.4 https://github.com/Burla-Cloud/burla.git --no-checkout
+RUN git clone --depth 1 --branch 1.2.5 https://github.com/Burla-Cloud/burla.git --no-checkout
 WORKDIR burla
 RUN git sparse-checkout init --cone && \
     git sparse-checkout set node_service && \
-    git checkout 1.2.4
+    git checkout 1.2.5
 WORKDIR node_service
 RUN python -m pip install --break-system-packages -e .

--- a/node_service/pyproject.toml
+++ b/node_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node-service"
-version = "1.2.4"
+version = "1.2.5"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "node_service", from = "src"}]

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -22,7 +22,7 @@ from starlette.datastructures import UploadFile
 from google.cloud import logging, secretmanager, firestore
 from google.cloud.compute_v1 import InstancesClient
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 CREDENTIALS, PROJECT_ID = google.auth.default()
 BURLA_BACKEND_URL = "https://backend.burla.dev"
 

--- a/worker_service/pyproject.toml
+++ b/worker_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "worker_service"
-version = "1.2.4"
+version = "1.2.5"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "worker_service", from = "src"}]


### PR DESCRIPTION
**Burla Release 1.2.5**
"The simplest way to run Python on lot's of computers"

- fix quickstart copy button!

To update run pip install burla==1.2.5