### PR TITLE
1.2.13

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "burla"
-version = "1.2.12"
+version = "1.2.13"
 description = "The simplest way to run Python on lot's of computers."
 authors = ["Jake Zuliani <jake@burla.dev>"]
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -4,7 +4,7 @@ from fire import Fire
 from appdirs import user_config_dir
 
 # needed so main_service can associate a client version with a request
-__version__ = "1.2.12"
+__version__ = "1.2.13"
 _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))

--- a/client/src/burla/_install.py
+++ b/client/src/burla/_install.py
@@ -163,9 +163,10 @@ def _install(spinner):
     # print success message
     msg = f"\nSuccessfully installed Burla v{__version__}!\n"
     msg += f"Quickstart:\n"
-    msg += f"  1. Run `burla login` to access your new dashboard.\n"
-    msg += f'  2. Hit "⏻ Start" on the homepage.\n'
-    msg += f"  3. Import and call `remote_parallel_map`!\n\n"
+    msg += f"  1. Open your new cluster dashboard: {dashboard_url}\n"
+    msg += f'  2. Hit "⏻ Start" to boot some machines!\n'
+    msg += f"  3. Run `burla login` to connect your laptop to the cluster.\n"
+    msg += f"  4. Import and call `remote_parallel_map`!\n\n"
     msg += f"Don't hesitate to E-Mail jake@burla.dev, or call me at 508-320-8778, thank you for using Burla!"
     spinner.write(msg)
 
@@ -446,10 +447,8 @@ def _create_firestore_database(spinner):
     cmd += f" --location=us-central1 --type=firestore-native"
     result = run_command(cmd, raise_error=False)
     if result.returncode != 0 and "already exists" in result.stderr.decode():
-        try:
+        if not client.collection("cluster_config").document("cluster_config").get().exists:
             collection = client.collection("cluster_config")
-            collection.document("cluster_config").update(DEFAULT_CLUSTER_CONFIG)
-        except NotFound:
             collection.document("cluster_config").set(DEFAULT_CLUSTER_CONFIG)
         spinner.text = "Creating Firestore database ... Database already exists."
         spinner.ok("✓")

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -3,11 +3,9 @@ import os
 from burla import remote_parallel_map
 
 
-def my_function(x):
+def create_vector_embedding(x):
 
-    print(os.getcwd())
-
-    print(f"hi #{x}")
+    pass
 
 
-remote_parallel_map(my_function, list(range(10)))
+remote_parallel_map(create_vector_embedding, list(range(5956034)))

--- a/examples/vector_embeddings/pyproject.toml
+++ b/examples/vector_embeddings/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.12"
 google-cloud-compute = "^1.33.0"
 google-auth = "^2.40.3"
 google-cloud-storage = "^3.2.0"
-burla = "^1.2.12"
+burla = "^1.2.13"
 
 
 [build-system]

--- a/main_service/makefile
+++ b/main_service/makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 .SILENT:
 
-BURLA_VERSION = 1.2.12
+BURLA_VERSION = 1.2.13
 WEBSERVICE_NAME = burla-main-service
 PYTHON_MODULE_NAME = main_service
 

--- a/main_service/pyproject.toml
+++ b/main_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "main_service"
-version = "1.2.12"
+version = "1.2.13"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>, Joseph Perry <joe@burla.dev>"]
 packages = [{include = "main_service", from = "src"}]

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -21,7 +21,7 @@ from jinja2 import Environment, FileSystemLoader
 os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
-CURRENT_BURLA_VERSION = "1.2.12"
+CURRENT_BURLA_VERSION = "1.2.13"
 
 # This is the only possible alternative "mode".
 # In this mode everything runs locally in docker containers.

--- a/node_service/Dockerfile
+++ b/node_service/Dockerfile
@@ -47,10 +47,10 @@ RUN ln -sf /usr/local/bin/python3.13 /usr/bin/python
 
 
 # Install latest node_service and pip install packages now to make node starts faster
-RUN git clone --depth 1 --branch 1.2.12 https://github.com/Burla-Cloud/burla.git --no-checkout
+RUN git clone --depth 1 --branch 1.2.13 https://github.com/Burla-Cloud/burla.git --no-checkout
 WORKDIR burla
 RUN git sparse-checkout init --cone && \
     git sparse-checkout set node_service && \
-    git checkout 1.2.12
+    git checkout 1.2.13
 WORKDIR node_service
 RUN python -m pip install --break-system-packages -e .

--- a/node_service/pyproject.toml
+++ b/node_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node-service"
-version = "1.2.12"
+version = "1.2.13"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "node_service", from = "src"}]

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -23,7 +23,7 @@ from starlette.datastructures import UploadFile
 from google.cloud import logging, secretmanager, firestore
 from google.cloud.compute_v1 import InstancesClient
 
-__version__ = "1.2.12"
+__version__ = "1.2.13"
 CREDENTIALS, PROJECT_ID = google.auth.default()
 BURLA_BACKEND_URL = "https://backend.burla.dev"
 

--- a/worker_service/pyproject.toml
+++ b/worker_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "worker_service"
-version = "1.2.12"
+version = "1.2.13"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "worker_service", from = "src"}]


### PR DESCRIPTION
**Burla Release 1.2.13**
"The simplest way to run Python on lot's of computers"

- Don't overwrite user cluster settings on install
- Increase clarity of error messages

To update run `pip install burla==1.2.13`