### PR TITLE
1.3.4

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "burla"
-version = "1.3.3"
+version = "1.3.4"
 description = "The simplest way to run Python on lot's of computers."
 authors = ["Jake Zuliani <jake@burla.dev>"]
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -4,7 +4,7 @@ from fire import Fire
 from appdirs import user_config_dir
 
 # needed so main_service can associate a client version with a request
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))

--- a/client/src/burla/_install.py
+++ b/client/src/burla/_install.py
@@ -127,7 +127,7 @@ def _install(spinner):
     # Deploy dashboard as google cloud run service
     spinner.text = "Deploying burla-main-service to Google Cloud Run ... "
     spinner.start()
-    image_name = f"us-docker.pkg.dev/burla-prod/burla-main-service/burla-main-service:1.3.2"  # {__version__}"
+    image_name = f"us-docker.pkg.dev/burla-prod/burla-main-service/burla-main-service:{__version__}"
     run_command(
         f"gcloud run deploy burla-main-service "
         f"--image={image_name} "

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.12"
 google-cloud-compute = "^1.33.0"
 google-auth = "^2.40.3"
 google-cloud-storage = "^3.2.0"
-burla = "^1.3.3"
+burla = "^1.3.4"
 xgboost = "^3.0.5"
 scikit-learn = "^1.7.2"
 

--- a/main_service/makefile
+++ b/main_service/makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 .SILENT:
 
-BURLA_VERSION = 1.3.3
+BURLA_VERSION = 1.3.4
 WEBSERVICE_NAME = burla-main-service
 PYTHON_MODULE_NAME = main_service
 

--- a/main_service/pyproject.toml
+++ b/main_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "main_service"
-version = "1.3.3"
+version = "1.3.4"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>, Joseph Perry <joe@burla.dev>"]
 packages = [{include = "main_service", from = "src"}]

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -22,7 +22,7 @@ from jinja2 import Environment, FileSystemLoader
 os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
-CURRENT_BURLA_VERSION = "1.3.3"
+CURRENT_BURLA_VERSION = "1.3.4"
 
 # In this mode EVERYTHING runs locally in docker containers.
 # possible modes: local-dev-mode (everything local), remote-dev-mode (only main-service local), prod

--- a/node_service/Dockerfile
+++ b/node_service/Dockerfile
@@ -77,11 +77,11 @@ RUN uv python install 3.13 && \
 
 # Install latest node_service and pip install packages now to make node starts faster
 WORKDIR /opt
-RUN git clone --depth 1 --branch 1.3.3 https://github.com/Burla-Cloud/burla.git --no-checkout
+RUN git clone --depth 1 --branch 1.3.4 https://github.com/Burla-Cloud/burla.git --no-checkout
 WORKDIR burla
 RUN git sparse-checkout init --cone && \
     git sparse-checkout set node_service && \
-    git checkout 1.3.3
+    git checkout 1.3.4
 WORKDIR node_service
 RUN uv venv /opt/burla/.venv
 RUN echo 'export UV_PROJECT_ENVIRONMENT=/opt/burla/.venv' >> /root/.bashrc

--- a/node_service/pyproject.toml
+++ b/node_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node-service"
-version = "1.3.3"
+version = "1.3.4"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "node_service", from = "src"}]

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -30,7 +30,7 @@ from starlette.requests import ClientDisconnect
 from starlette.datastructures import UploadFile
 
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 CREDENTIALS, PROJECT_ID = google.auth.default()
 BURLA_BACKEND_URL = "https://backend.burla.dev"
 

--- a/worker_service/pyproject.toml
+++ b/worker_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "worker_service"
-version = "1.3.3"
+version = "1.3.4"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "worker_service", from = "src"}]


### PR DESCRIPTION
**Burla Release 1.3.4**
_"The world's simplest cluster compute software"_

![images](https://github.com/user-attachments/assets/20891d69-f689-4287-aae1-99ac2fad7e7f)
(fix hardcoded version left in install script)

To update run `pip install burla==1.3.4`