### PR TITLE
1.5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,7 +198,6 @@ main_service/frontend/.vscode/
 main_service/main_svc_last_started_at.txt
 main_service/.frontend_last_built_at.txt
 .temp_token.txt
-.burla_cluster_dashboard_url_before_dev
 _worker_service_python_env/*
 _shared_workspace/*
 main_service/src/main_service/static/assets/*

--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,5 @@ _worker_service_python_env/*
 _shared_workspace/*
 main_service/src/main_service/static/assets/*
 _python_version_marker/*
+_node_auth/*
 .cursor/

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "burla"
-version = "1.5.5"
+version = "1.5.6"
 description = "Easy to use cluster-compute software."
 requires-python = ">=3.11"
 dependencies = [

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -6,7 +6,7 @@ from fire import Fire
 from platformdirs import user_config_dir
 
 # needed so main_service can associate a client version with a request
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -1,3 +1,5 @@
+import json
+import os
 from pathlib import Path
 
 from fire import Fire
@@ -9,6 +11,19 @@ _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))
 CONFIG_PATH = _appdata_dir / Path("burla_credentials.json")
+
+
+def get_cluster_dashboard_url() -> str:
+    """
+    Resolve the main_service URL. `BURLA_CLUSTER_DASHBOARD_URL` wins if set -
+    this is how `make local-dev` / `make remote-dev` point the client at the
+    in-shell dev server without mutating the user's credentials file.
+    """
+    override = os.environ.get("BURLA_CLUSTER_DASHBOARD_URL")
+    if override:
+        return override.rstrip("/")
+    return json.loads(CONFIG_PATH.read_text())["cluster_dashboard_url"].rstrip("/")
+
 
 from burla._auth import login
 from burla._install import install

--- a/client/src/burla/_auth.py
+++ b/client/src/burla/_auth.py
@@ -13,7 +13,6 @@ from burla._helpers import run_command
 
 AUTH_TIMEOUT_SECONDS = 180
 IN_COLAB = os.getenv("COLAB_RELEASE_TAG") is not None
-LOCAL_CLUSTER_DASHBOARD_URL = "http://localhost:5001"
 
 
 class AuthTimeoutException(Exception):
@@ -42,16 +41,6 @@ def get_auth_headers() -> dict[str, str]:
         "X-User-Email": email,
         "Authorization": f"Bearer {auth_token}",
     }
-
-
-def _cluster_dashboard_url_to_write(cluster_dashboard_url: str) -> str:
-    if not CONFIG_PATH.exists():
-        return cluster_dashboard_url
-    config = json.loads(CONFIG_PATH.read_text())
-    current_cluster_dashboard_url = config.get("cluster_dashboard_url")
-    if current_cluster_dashboard_url == LOCAL_CLUSTER_DASHBOARD_URL:
-        return LOCAL_CLUSTER_DASHBOARD_URL
-    return cluster_dashboard_url
 
 
 def _get_login_response(client_id, spinner, attempt=0):
@@ -112,7 +101,6 @@ def login(no_browser: bool = False):
         auth_token, email, project_id, cluster_dashboard_url = _get_login_response(
             client_id, spinner
         )
-    cluster_dashboard_url = _cluster_dashboard_url_to_write(cluster_dashboard_url)
 
     print(f"\nYou are now logged in to [{project_id}] as [{email}].")
     print("Please email jake@burla.dev with any questions!\n")

--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -6,13 +6,12 @@ the cluster; firestore is never touched from the client directly.
 Each method maps one-to-one to a main_service endpoint.
 """
 
-import json
 from typing import Optional
 
 import aiohttp
 import requests
 
-from burla import CONFIG_PATH
+from burla import get_cluster_dashboard_url
 from burla._auth import get_auth_headers
 
 
@@ -51,14 +50,13 @@ def _build_patch_job_body(
 class ClusterClient:
     """
     Thin wrapper around main_service HTTP endpoints. Construction is free -
-    only reads the cluster dashboard URL from CONFIG_PATH; every call goes
-    over the provided `aiohttp.ClientSession`.
+    only resolves the cluster dashboard URL; every call goes over the
+    provided `aiohttp.ClientSession`.
     """
 
     def __init__(self, session: aiohttp.ClientSession):
-        config = json.loads(CONFIG_PATH.read_text())
         self.session = session
-        self._url = config["cluster_dashboard_url"].rstrip("/")
+        self._url = get_cluster_dashboard_url()
 
     async def _request(
         self,
@@ -170,8 +168,7 @@ class ClusterClient:
         an event loop is not available. Swallows any failure - if
         main_service is unreachable the cancel flow still proceeds locally.
         """
-        config = json.loads(CONFIG_PATH.read_text())
-        url = f"{config['cluster_dashboard_url'].rstrip('/')}/v1/jobs/{job_id}"
+        url = f"{get_cluster_dashboard_url()}/v1/jobs/{job_id}"
         body = _build_patch_job_body(updates, append_fail_reason)
         try:
             requests.patch(url, json=body, headers=get_auth_headers(), timeout=10)

--- a/client/src/burla/_helpers.py
+++ b/client/src/burla/_helpers.py
@@ -1,4 +1,3 @@
-import json
 import os
 import sys
 import signal
@@ -9,7 +8,7 @@ from threading import Event
 
 from yaspin import Spinner
 
-from burla import CONFIG_PATH
+from burla import get_cluster_dashboard_url
 
 POSIX_SIGNALS_TO_HANDLE = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"]
 NT_SIGNALS_TO_HANDLE = ["SIGINT", "SIGBREAK"]
@@ -90,7 +89,7 @@ def install_signal_handlers(
             )
 
         if background and inputs_done_event.is_set():
-            main_service_url = json.loads(CONFIG_PATH.read_text())["cluster_dashboard_url"]
+            main_service_url = get_cluster_dashboard_url()
             job_url = f"{main_service_url}/jobs/{job_id}"
             msg = "Background mode is enabled.\n"
             msg += f"This job will continue running on the cluster, to monitor progress go to:"

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -13,7 +13,7 @@ from aiohttp import ClientConnectorError, ClientError, ClientOSError, ClientTime
 from tblib import Traceback
 from yaspin import Spinner
 
-from burla import CONFIG_PATH
+from burla import get_cluster_dashboard_url
 from burla._auth import get_auth_headers
 from burla._cluster_client import ClusterClient, _local_host_from
 from burla._reporting import RemoteParallelMapReporter
@@ -175,13 +175,13 @@ async def wait_for_nodes_to_be_ready(
             n_booting_nodes = state["booting_count"]
             ready_nodes = state["ready_nodes"]
         if not ready_nodes:
-            main_service_url = json.loads(CONFIG_PATH.read_text())["cluster_dashboard_url"]
+            main_service_url = get_cluster_dashboard_url()
             msg = "\n\nZero nodes are ready after Booting. Did they fail to boot?\n"
             msg += f"Check your clsuter dashboard at: {main_service_url}\n\n"
             raise NoNodes(msg)
 
     if n_booting_nodes == 0 and n_running_nodes == 0 and len(ready_nodes) == 0:
-        main_service_url = json.loads(CONFIG_PATH.read_text())["cluster_dashboard_url"]
+        main_service_url = get_cluster_dashboard_url()
         msg = "\n\nZero nodes are ready. Is your cluster turned on?\n"
         msg += f'Go to {main_service_url} and hit "⏻ Start" to turn it on!\n\n'
         raise NoNodes(msg)
@@ -302,6 +302,7 @@ class Node:
             "packages": packages,
             "start_time": start_time,
             "node_ids_expected": assigned_node_ids,
+            "cluster_dashboard_url": self.client._url,
         }
         url = f"{self.host}/jobs/{job_id}"
         timeout = aiohttp.ClientTimeout(120)

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -10,7 +10,9 @@ from importlib import metadata
 from queue import Queue
 from threading import Event, Thread
 from time import time
-from typing import Callable, Optional, Union
+from typing import Callable, Literal, Optional, Union
+
+FuncGpu = Literal["A100", "A100_40G", "A100_80G", "H100", "H100_80G"]
 from uuid import uuid4
 
 import aiohttp
@@ -117,6 +119,8 @@ async def _execute_job(
     start_time: float,
     udf_error_event: Event,
     grow: bool,
+    image: Optional[str],
+    func_gpu: Optional[FuncGpu],
     session: aiohttp.ClientSession,
     session_stack: AsyncExitStack,
     reporter: RemoteParallelMapReporter,
@@ -149,6 +153,8 @@ async def _execute_job(
         "started_at": start_time,
         "is_background_job": background,
         "grow": grow,
+        "image": image,
+        "func_gpu": func_gpu,
     }
     # On 503 nodes_busy, show boot progress via the polling loop then try
     # once more. Any other known error surfaces as its domain exception
@@ -305,11 +311,13 @@ def remote_parallel_map(
     inputs: list,
     func_cpu: int = 1,
     func_ram: int = 4,
+    func_gpu: Optional[FuncGpu] = None,
+    image: Optional[str] = None,
+    grow: bool = False,
+    max_parallelism: Optional[int] = None,
     detach: bool = False,
     generator: bool = False,
     spinner: bool = True,
-    max_parallelism: Optional[int] = None,
-    grow: bool = False,
 ):
     """
     Run a Python function on many remote computers in parallel.
@@ -331,6 +339,19 @@ def remote_parallel_map(
             The number of CPUs allocated for each instance of `function_`. Defaults to 1.
         func_ram (int, optional):
             The amount of RAM (in GB) allocated for each instance of `function_`. Defaults to 4.
+        func_gpu (str, optional):
+            Allocate one GPU per function call. One of: "A100" / "A100_40G",
+            "A100_80G", "H100" / "H100_80G". Defaults to None (no GPU).
+        image (str, optional):
+            If provided, only nodes running this container image are eligible. When
+            `grow=True` and no matching nodes are available, newly booted nodes will
+            run this image. Defaults to None (no image filter).
+        grow (bool, optional):
+            If True, adds nodes to the cluster (grows) to complete the job as quickly
+            as possible. Adds up to 2560 cpus.
+        max_parallelism (int, optional):
+            The maximum number of `function_` instances allowed to be running at the same time.
+            Defaults to the number of provided inputs.
         detach (bool, optional):
             If True, job will continue running on cluster, when canceled locally.
             Defaults to False.
@@ -339,12 +360,6 @@ def remote_parallel_map(
             returns a list of outputs once all have been processed. Defaults to False.
         spinner (bool, optional):
             If set to False, disables the display of the status indicator/spinner. Defaults to True.
-        max_parallelism (int, optional):
-            The maximum number of `function_` instances allowed to be running at the same time.
-            Defaults to the number of provided inputs.
-        grow (bool, optional):
-            If True, adds nodes to the cluster (grows) to complete the job as quickly
-            as possible. Adds up to 2560 cpus.
 
     Returns:
         List[Any] or Generator[Any, None, None]:
@@ -477,6 +492,8 @@ def remote_parallel_map(
                         generator=generator,
                         udf_error_event=udf_error_event,
                         grow=grow,
+                        image=image,
+                        func_gpu=func_gpu,
                     )
                 )
             except Exception:

--- a/client/tests/test.py
+++ b/client/tests/test.py
@@ -2,17 +2,14 @@
 The tests here assume the cluster is running in "local-dev-mode".
 """
 
-from pathlib import Path
 from time import sleep
 import multiprocessing as mp
+import os
 import queue
 import io
-import sys
 import contextlib
 import traceback
-import json
 import pytest
-import burla
 from burla import remote_parallel_map
 
 
@@ -20,47 +17,27 @@ N_INPUTS = 100
 MAX_RUNTIME_SECONDS_WHEN_READY = 30
 
 
-def _run_test_base_in_subprocess(result_queue):
+def _run_rpm_in_subprocess(result_queue, function_source, inputs):
     function_namespace = {}
-    exec(
-        "def test_function(test_input):\n" "    print('hi')\n" "    return test_input\n",
-        {},
-        function_namespace,
-    )
+    exec(function_source, {}, function_namespace)
     test_function = function_namespace["test_function"]
 
     stdout_buffer = io.StringIO()
     try:
-        config_json = json.loads(burla.CONFIG_PATH.read_text())
-        local_dev_config = {**config_json, "cluster_dashboard_url": "http://localhost:5001"}
-        temp_config_path = Path("/tmp/burla_local_dev_test_credentials.json")
-        temp_config_path.write_text(json.dumps(local_dev_config))
-
-        # Every burla submodule that does `from burla import CONFIG_PATH`
-        # captures its own reference at import time, so just reassigning
-        # `burla.CONFIG_PATH` does not propagate. Patch every already-imported
-        # burla.* module that holds a `CONFIG_PATH` attribute instead of
-        # enumerating consumers by hand (which has silently rotted before).
-        burla.CONFIG_PATH = temp_config_path
-        for name, module in list(sys.modules.items()):
-            if not name.startswith("burla"):
-                continue
-            if hasattr(module, "CONFIG_PATH"):
-                module.CONFIG_PATH = temp_config_path
-
+        os.environ["BURLA_CLUSTER_DASHBOARD_URL"] = "http://localhost:5001"
         with contextlib.redirect_stdout(stdout_buffer):
-            outputs = remote_parallel_map(
-                test_function, list(range(N_INPUTS)), spinner=False, grow=True
-            )
+            outputs = remote_parallel_map(test_function, inputs, spinner=False, grow=True)
         result_queue.put({"ok": True, "stdout": stdout_buffer.getvalue(), "outputs": outputs})
     except Exception:
         result_queue.put({"ok": False, "traceback": traceback.format_exc()})
 
 
-def _run_with_timeout(timeout_seconds):
+def _run_with_timeout(function_source, inputs, timeout_seconds):
     context = mp.get_context("spawn")
     result_queue = context.Queue()
-    process = context.Process(target=_run_test_base_in_subprocess, args=(result_queue,))
+    process = context.Process(
+        target=_run_rpm_in_subprocess, args=(result_queue, function_source, inputs)
+    )
     process.start()
     process.join(timeout_seconds)
 
@@ -84,12 +61,19 @@ def _run_with_timeout(timeout_seconds):
 
 
 def test_base():
-    result = _run_with_timeout(MAX_RUNTIME_SECONDS_WHEN_READY)
+    function_source = "def test_function(test_input):\n    print('hi')\n    return test_input\n"
+    result = _run_with_timeout(function_source, list(range(N_INPUTS)), MAX_RUNTIME_SECONDS_WHEN_READY)
     stdout_lines = [line.strip() for line in result["stdout"].splitlines()]
     hi_count = sum(1 for line in stdout_lines if line == "hi")
     assert len(result["outputs"]) == N_INPUTS
     assert set(result["outputs"]) == set(range(N_INPUTS))
     assert hi_count == N_INPUTS
+
+
+def test_cwd_is_workspace():
+    function_source = "def test_function(_):\n    import os\n    return os.getcwd()\n"
+    result = _run_with_timeout(function_source, [None], MAX_RUNTIME_SECONDS_WHEN_READY)
+    assert result["outputs"] == ["/workspace"]
 
 
 def _test_big_function():

--- a/client/uv.lock
+++ b/client/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "burla"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/main_service/makefile
+++ b/main_service/makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 .SILENT:
 
-BURLA_VERSION = 1.5.5
+BURLA_VERSION = 1.5.6
 WEBSERVICE_NAME = burla-main-service
 PYTHON_MODULE_NAME = main_service
 

--- a/main_service/pyproject.toml
+++ b/main_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "main_service"
-version = "1.5.5"
+version = "1.5.6"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>, Joseph Perry <joe@burla.dev>"]
 packages = [{include = "main_service", from = "src"}]

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -25,7 +25,7 @@ from jinja2 import Environment, FileSystemLoader
 os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
-CURRENT_BURLA_VERSION = "1.5.5"
+CURRENT_BURLA_VERSION = "1.5.6"
 MIN_COMPATIBLE_CLIENT_VERSION = "1.5.5"
 
 # In this mode EVERYTHING runs locally in docker containers.
@@ -271,9 +271,7 @@ async def lifespan(app: FastAPI):
     # window see an empty NODES_CACHE and can spuriously 404. If firestore
     # is unreachable we time out and proceed anyway (degraded to old race
     # behavior rather than failing startup outright).
-    warmed = await asyncio.to_thread(
-        _nodes_cache_ready.wait, _NODES_CACHE_READY_TIMEOUT_SEC
-    )
+    warmed = await asyncio.to_thread(_nodes_cache_ready.wait, _NODES_CACHE_READY_TIMEOUT_SEC)
     if not warmed:
         print(
             f"NODES_CACHE did not warm within {_NODES_CACHE_READY_TIMEOUT_SEC}s; "

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -46,6 +46,7 @@ from main_service.helpers import (
 )
 from main_service.node import Node
 from main_service.endpoints.cluster_lifecycle import (
+    GROW_INACTIVITY_SHUTDOWN_TIME_SEC,
     LOCAL_DEV_MAX_GROW_CPUS,
     MAX_GROW_CPUS,
     _get_cluster_config,
@@ -254,6 +255,7 @@ def _grow_if_needed(
         job_id,
         node_machine_types,
         containers_override,
+        GROW_INACTIVITY_SHUTDOWN_TIME_SEC,
     )
     return [
         {

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -18,6 +18,7 @@ you add a dashboard endpoint, put it in one of the files above.
 import asyncio
 import math
 from time import time
+from typing import Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -38,6 +39,8 @@ from main_service import (
 )
 from main_service.helpers import (
     Logger,
+    gpu_machine_prefix,
+    gpu_machine_type,
     parallelism_capacity,
     parse_version,
 )
@@ -117,17 +120,36 @@ async def patch_job_doc(job_id: str, request: Request):
 # ------------------------------------------------------------------
 
 
-def _select_ready_nodes_from_cache(func_cpu: int, func_ram: int, max_parallelism: int):
+def _select_ready_nodes_from_cache(
+    func_cpu: int,
+    func_ram: int,
+    max_parallelism: int,
+    image: Optional[str],
+    func_gpu: Optional[str],
+):
     """Walk the ready-node cache, picking unreserved ones that fit the
     requested per-function resources, up to `max_parallelism` total slots.
-    Returns (selected_nodes, total_parallelism).
+    When `image` is set, only nodes running that container are eligible.
+    When `func_gpu` is set, only nodes on a matching GPU family are eligible.
+    Returns (selected_nodes, total_parallelism, ready_nodes).
     """
+    machine_prefix = gpu_machine_prefix(func_gpu)
     with _nodes_cache_lock:
         all_nodes = list(NODES_CACHE.values())
     ready_nodes = [
         n for n in all_nodes
         if n.get("status") == "READY" and not n.get("reserved_for_job")
     ]
+    if image:
+        ready_nodes = [
+            n for n in ready_nodes
+            if image in [c["image"] for c in n.get("containers") or []]
+        ]
+    if machine_prefix:
+        ready_nodes = [
+            n for n in ready_nodes
+            if (n.get("machine_type") or "").startswith(machine_prefix)
+        ]
 
     selected = []
     total_parallelism = 0
@@ -158,6 +180,8 @@ def _grow_if_needed(
     max_parallelism: int,
     func_cpu: int,
     func_ram: int,
+    image: Optional[str],
+    func_gpu: Optional[str],
     job_id: str,
     logger: Logger,
     auth_headers: dict,
@@ -165,45 +189,60 @@ def _grow_if_needed(
 ) -> list[dict]:
     """Schedules `_start_nodes` in the background and returns one
     `{instance_name, target_parallelism}` dict per reserved booting node.
-    Empty list if no growth was needed."""
+    Empty list if no growth was needed.
+
+    When `func_gpu` is set, each new node is one of the mapped single-GPU
+    machine types and contributes exactly one parallelism slot. When `image`
+    is set, the new nodes run that image instead of the cluster default.
+    """
     requested_parallelism = min(n_inputs, max_parallelism)
-    required_cpus_for_ram = (func_ram + 3) // 4
-    required_cpus_per_call = max(func_cpu, required_cpus_for_ram)
-    target_cpus = requested_parallelism * required_cpus_per_call
-    current_cpus = target_parallelism * required_cpus_per_call
-    missing_cpus = max(0, target_cpus - current_cpus)
-    if missing_cpus <= 0:
-        return []
+    gpu_mt = gpu_machine_type(func_gpu)
 
-    max_cpu = LOCAL_DEV_MAX_GROW_CPUS if IN_LOCAL_DEV_MODE else MAX_GROW_CPUS
-    max_additional_cpus = max(0, max_cpu - current_cpus)
-    num_cpus_to_add = min(missing_cpus, max_additional_cpus)
-    if num_cpus_to_add <= 0:
-        return []
-
-    config = _get_cluster_config()
-    node_spec = config["Nodes"][0]
-    configured_machine_type = node_spec["machine_type"]
-
-    # For CPU (n4-standard) clusters, ignore the configured size and pack the
-    # required CPUs into as many n4-standard-80s as fit, with the remainder
-    # covered by the smallest n4-standard that fits. GPU clusters keep using
-    # the configured machine type so GPU jobs still land on GPU hardware.
-    # Local dev stays homogeneous because node containers hard-code 2 workers
-    # regardless of the advertised machine_type (see INSTANCE_N_CPUS).
-    pack_by_size = (
-        not IN_LOCAL_DEV_MODE
-        and configured_machine_type.startswith("n4-standard-")
-    )
-
-    if pack_by_size:
-        node_machine_types = _pack_n4_standard_machines(num_cpus_to_add)
+    if gpu_mt:
+        missing_nodes = max(0, requested_parallelism - target_parallelism)
+        if missing_nodes <= 0:
+            return []
+        node_machine_types = [gpu_mt] * missing_nodes
+        config = _get_cluster_config()
     else:
-        cpu_per_node = _machine_type_cpu_count(configured_machine_type)
-        n_nodes_to_add = math.ceil(num_cpus_to_add / cpu_per_node)
-        node_machine_types = [configured_machine_type] * n_nodes_to_add
+        required_cpus_for_ram = (func_ram + 3) // 4
+        required_cpus_per_call = max(func_cpu, required_cpus_for_ram)
+        target_cpus = requested_parallelism * required_cpus_per_call
+        current_cpus = target_parallelism * required_cpus_per_call
+        missing_cpus = max(0, target_cpus - current_cpus)
+        if missing_cpus <= 0:
+            return []
+
+        max_cpu = LOCAL_DEV_MAX_GROW_CPUS if IN_LOCAL_DEV_MODE else MAX_GROW_CPUS
+        max_additional_cpus = max(0, max_cpu - current_cpus)
+        num_cpus_to_add = min(missing_cpus, max_additional_cpus)
+        if num_cpus_to_add <= 0:
+            return []
+
+        config = _get_cluster_config()
+        node_spec = config["Nodes"][0]
+        configured_machine_type = node_spec["machine_type"]
+
+        # For CPU (n4-standard) clusters, ignore the configured size and pack the
+        # required CPUs into as many n4-standard-80s as fit, with the remainder
+        # covered by the smallest n4-standard that fits. GPU clusters keep using
+        # the configured machine type so GPU jobs still land on GPU hardware.
+        # Local dev stays homogeneous because node containers hard-code 2 workers
+        # regardless of the advertised machine_type (see INSTANCE_N_CPUS).
+        pack_by_size = (
+            not IN_LOCAL_DEV_MODE
+            and configured_machine_type.startswith("n4-standard-")
+        )
+
+        if pack_by_size:
+            node_machine_types = _pack_n4_standard_machines(num_cpus_to_add)
+        else:
+            cpu_per_node = _machine_type_cpu_count(configured_machine_type)
+            n_nodes_to_add = math.ceil(num_cpus_to_add / cpu_per_node)
+            node_machine_types = [configured_machine_type] * n_nodes_to_add
 
     node_instance_names = [f"burla-node-{uuid4().hex[:8]}" for _ in node_machine_types]
+    containers_override = [{"image": image}] if image else None
 
     add_background_task(
         _start_nodes,
@@ -214,6 +253,7 @@ def _grow_if_needed(
         node_instance_names,
         job_id,
         node_machine_types,
+        containers_override,
     )
     return [
         {
@@ -264,6 +304,8 @@ async def start_job(
     n_inputs = int(body["n_inputs"])
     max_parallelism = int(body.get("max_parallelism") or n_inputs)
     grow = bool(body.get("grow"))
+    image = body.get("image")
+    func_gpu = body.get("func_gpu")
     client_version = body["burla_client_version"]
 
     # --- version check ---
@@ -284,9 +326,19 @@ async def start_job(
             },
         )
 
+    # --- validate func_gpu early so both selection and grow can assume it maps cleanly ---
+    try:
+        gpu_machine_type(func_gpu)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error))
+
     # --- select from cached ready nodes ---
     ready, target_parallelism, all_ready = _select_ready_nodes_from_cache(
-        func_cpu=func_cpu, func_ram=func_ram, max_parallelism=max_parallelism
+        func_cpu=func_cpu,
+        func_ram=func_ram,
+        max_parallelism=max_parallelism,
+        image=image,
+        func_gpu=func_gpu,
     )
 
     if not ready and not grow:
@@ -318,6 +370,8 @@ async def start_job(
             max_parallelism=max_parallelism,
             func_cpu=func_cpu,
             func_ram=func_ram,
+            image=image,
+            func_gpu=func_gpu,
             job_id=job_id,
             logger=logger,
             auth_headers=auth_headers,
@@ -332,6 +386,8 @@ async def start_job(
         "n_inputs": n_inputs,
         "func_cpu": func_cpu,
         "func_ram": func_ram,
+        "image": image,
+        "func_gpu": func_gpu,
         "packages": body.get("packages") or {},
         "status": "RUNNING",
         "burla_client_version": client_version,

--- a/main_service/src/main_service/endpoints/cluster_lifecycle.py
+++ b/main_service/src/main_service/endpoints/cluster_lifecycle.py
@@ -1,6 +1,7 @@
 import docker
 from datetime import datetime, timezone
 from time import time
+from typing import Optional
 
 from fastapi import APIRouter, Depends
 from google.cloud.firestore_v1.base_query import FieldFilter
@@ -21,6 +22,11 @@ from main_service.helpers import Logger, log_telemetry
 router = APIRouter()
 MAX_GROW_CPUS = 2560
 LOCAL_DEV_MAX_GROW_CPUS = 4
+
+# Nodes booted by /v1/cluster/grow always get a short inactivity timeout
+# regardless of the cluster-config value, so a burst-scaled job doesn't leave
+# expensive hardware sitting idle long after the job finishes.
+GROW_INACTIVITY_SHUTDOWN_TIME_SEC = 60
 
 # Priced n4-standard sizes the dashboard exposes, largest first. n4-standard-48
 # is intentionally omitted to match `main_service/frontend/src/types/constants.ts`
@@ -125,6 +131,7 @@ def _start_nodes(
     reserved_for_job: str = None,
     node_machine_types: list[str] = None,
     containers_override: list[dict] = None,
+    inactivity_shutdown_time_sec_override: Optional[int] = None,
 ):
     node_service_port = _current_local_dev_max_node_port()
     futures = []
@@ -147,6 +154,11 @@ def _start_nodes(
                 if node_machine_types is not None
                 else node_spec["machine_type"]
             )
+            inactivity_timeout = (
+                inactivity_shutdown_time_sec_override
+                if inactivity_shutdown_time_sec_override is not None
+                else node_spec.get("inactivity_shutdown_time_sec")
+            )
             node_start_kwargs = dict(
                 db=DB,
                 logger=logger,
@@ -159,7 +171,7 @@ def _start_nodes(
                 service_port=node_service_port,
                 sync_gcs_bucket_name=config["gcs_bucket_name"],
                 as_local_container=IN_LOCAL_DEV_MODE,
-                inactivity_shutdown_time_sec=node_spec.get("inactivity_shutdown_time_sec"),
+                inactivity_shutdown_time_sec=inactivity_timeout,
                 disk_size=node_spec.get("disk_size_gb"),
                 instance_name=instance_name,
                 reserved_for_job=reserved_for_job,

--- a/main_service/src/main_service/endpoints/cluster_lifecycle.py
+++ b/main_service/src/main_service/endpoints/cluster_lifecycle.py
@@ -124,6 +124,7 @@ def _start_nodes(
     node_instance_names: list[str] = None,
     reserved_for_job: str = None,
     node_machine_types: list[str] = None,
+    containers_override: list[dict] = None,
 ):
     node_service_port = _current_local_dev_max_node_port()
     futures = []
@@ -136,6 +137,7 @@ def _start_nodes(
 
     for node_spec in config["Nodes"]:
         quantity = node_spec["quantity"] if n_nodes_to_add is None else n_nodes_to_add
+        spec_containers = containers_override or node_spec["containers"]
         for index in range(quantity):
             if IN_LOCAL_DEV_MODE:
                 node_service_port += 1
@@ -150,7 +152,7 @@ def _start_nodes(
                 logger=logger,
                 machine_type=machine_type,
                 gcp_region=node_spec["gcp_region"],
-                containers=[Container.from_dict(c) for c in node_spec["containers"]],
+                containers=[Container.from_dict(c) for c in spec_containers],
                 auth_headers=auth_headers,
                 instance_client=instance_client,
                 machine_types_client=machine_types_client,

--- a/main_service/src/main_service/helpers.py
+++ b/main_service/src/main_service/helpers.py
@@ -60,6 +60,44 @@ def parallelism_capacity(machine_type: str, func_cpu: int, func_ram: int) -> int
     raise ValueError("machine_type must be: n4-standard-X, a3-highgpu-Xg, or a3-ultragpu-8g")
 
 
+# Maps the `func_gpu` strings users pass to `remote_parallel_map` to the
+# smallest GCP machine_type with that GPU. Only single-GPU-per-function-call
+# is supported; filtering by GPU family prefix lets larger variants
+# (e.g. `a2-highgpu-2g`) still serve a `func_gpu="A100"` request.
+_GPU_MACHINE_TYPES = {
+    "A100": "a2-highgpu-1g",
+    "A100_40G": "a2-highgpu-1g",
+    "A100_80G": "a2-ultragpu-1g",
+    "H100": "a3-highgpu-1g",
+    "H100_80G": "a3-highgpu-1g",
+}
+
+
+def gpu_machine_type(func_gpu: Optional[str]) -> Optional[str]:
+    """Resolve a user-facing `func_gpu` string to its target GCP machine_type.
+
+    Returns None when `func_gpu` is None (no GPU requested).
+    Raises ValueError for unknown strings.
+    """
+    if func_gpu is None:
+        return None
+    if func_gpu not in _GPU_MACHINE_TYPES:
+        raise ValueError(f"func_gpu must be one of {sorted(_GPU_MACHINE_TYPES)}")
+    return _GPU_MACHINE_TYPES[func_gpu]
+
+
+def gpu_machine_prefix(func_gpu: Optional[str]) -> Optional[str]:
+    """Return the GPU-family prefix (e.g. `a2-highgpu-`) for a `func_gpu` string.
+
+    Used to filter existing ready nodes so an `a2-highgpu-2g`/`4g`/`8g` node
+    can serve a `func_gpu="A100"` request.
+    """
+    machine_type = gpu_machine_type(func_gpu)
+    if machine_type is None:
+        return None
+    return machine_type.rsplit("-", 1)[0] + "-"
+
+
 def parse_version(version_str: str) -> tuple[int, ...]:
     """Tuple-compare-friendly version parse. Assumes MAJOR.MINOR.PATCH."""
     return tuple(int(part) for part in version_str.split("."))

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -266,6 +266,11 @@ class Node:
                 f"{os.environ['HOST_PWD']}/_shared_workspace": "/workspace/shared",
                 f"{os.environ['HOST_PWD']}/_worker_service_python_env": "/worker_service_python_env",
                 f"{os.environ['HOST_PWD']}/_python_version_marker": "/python_version_marker",
+                # Shared with every worker container this node spawns at
+                # /root/.config/burla, which is what burla's CONFIG_PATH
+                # resolves to inside those containers. Lets nested
+                # remote_parallel_map calls authenticate without a login.
+                f"{os.environ['HOST_PWD']}/_node_auth": "/opt/burla/node_auth",
                 "/var/run/docker.sock": "/var/run/docker.sock",
             },
         )

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -266,10 +266,8 @@ class Node:
                 f"{os.environ['HOST_PWD']}/_shared_workspace": "/workspace/shared",
                 f"{os.environ['HOST_PWD']}/_worker_service_python_env": "/worker_service_python_env",
                 f"{os.environ['HOST_PWD']}/_python_version_marker": "/python_version_marker",
-                # Shared with every worker container this node spawns at
-                # /root/.config/burla, which is what burla's CONFIG_PATH
-                # resolves to inside those containers. Lets nested
-                # remote_parallel_map calls authenticate without a login.
+                # Paired with the matching mount in every worker container;
+                # see NODE_AUTH_DIR in node_service/__init__.py.
                 f"{os.environ['HOST_PWD']}/_node_auth": "/opt/burla/node_auth",
                 "/var/run/docker.sock": "/var/run/docker.sock",
             },

--- a/make/cluster_dashboard_dev_state.py
+++ b/make/cluster_dashboard_dev_state.py
@@ -1,52 +1,5 @@
-import json
 import os
 import sys
-from pathlib import Path
-
-from platformdirs import user_config_dir
-
-STATE_PATH = Path(".burla_cluster_dashboard_url_before_dev")
-CREDENTIALS_PATH = Path(user_config_dir("burla", "burla")) / "burla_credentials.json"
-LOCAL_CLUSTER_DASHBOARD_URL = "http://localhost:5001"
-
-
-def point_at_local_dashboard():
-    CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    config = json.loads(CREDENTIALS_PATH.read_text()) if CREDENTIALS_PATH.exists() else {}
-    config["cluster_dashboard_url"] = LOCAL_CLUSTER_DASHBOARD_URL
-    CREDENTIALS_PATH.write_text(json.dumps(config))
-
-
-def save():
-    if not CREDENTIALS_PATH.exists():
-        STATE_PATH.write_text("__NO_FILE__")
-    else:
-        data = json.loads(CREDENTIALS_PATH.read_text())
-        if "cluster_dashboard_url" not in data:
-            STATE_PATH.write_text("__NO_KEY__")
-        else:
-            STATE_PATH.write_text(data["cluster_dashboard_url"])
-
-
-def restore():
-    if not STATE_PATH.exists():
-        return
-    previous = STATE_PATH.read_text()
-    STATE_PATH.unlink()
-    if previous == "__NO_FILE__":
-        if CREDENTIALS_PATH.exists():
-            CREDENTIALS_PATH.unlink()
-        return
-    if previous == "__NO_KEY__":
-        if CREDENTIALS_PATH.exists():
-            data = json.loads(CREDENTIALS_PATH.read_text())
-            data.pop("cluster_dashboard_url", None)
-            CREDENTIALS_PATH.write_text(json.dumps(data))
-        return
-    if CREDENTIALS_PATH.exists():
-        data = json.loads(CREDENTIALS_PATH.read_text())
-        data["cluster_dashboard_url"] = previous
-        CREDENTIALS_PATH.write_text(json.dumps(data))
 
 
 def delete_booting_nodes():
@@ -66,11 +19,5 @@ def delete_booting_nodes():
 
 if __name__ == "__main__":
     command = sys.argv[1]
-    if command == "save":
-        save()
-    elif command == "restore":
-        restore()
-    elif command == "point":
-        point_at_local_dashboard()
-    elif command == "delete_booting_nodes":
+    if command == "delete_booting_nodes":
         delete_booting_nodes()

--- a/makefile
+++ b/makefile
@@ -64,6 +64,10 @@ local-dev:
 	rm -rf ./_shared_workspace; \
 	mkdir -p ./_shared_workspace; \
 	chmod 777 ./_shared_workspace; \
+	echo "Removing _node_auth"; \
+	rm -rf ./_node_auth; \
+	mkdir -p ./_node_auth; \
+	chmod 777 ./_node_auth; \
 	echo "Starting local dev"; \
 	docker network create local-burla-cluster 2>/dev/null || true; \
 	gcloud auth print-access-token > .temp_token.txt; \

--- a/makefile
+++ b/makefile
@@ -10,12 +10,12 @@ define UV_ZSH_ENV
 	uv python pin --project $(PROJECT_ABS) $(1) >/dev/null 2>&1
 	uv sync --project $(PROJECT_ABS) --group $(2) >/dev/null 2>&1
 	tmp_dir=$$(mktemp -d); \
-	printf 'PROMPT="($(1)-$(2)) %%c %%%% "\n' > $$tmp_dir/.zshrc; \
+	printf 'PROMPT="($(1)-$(2)) %%c %%%% "\nexport BURLA_CLUSTER_DASHBOARD_URL=http://localhost:5001\n' > $$tmp_dir/.zshrc; \
 	trap 'rm -rf $$tmp_dir' EXIT; \
 	ZDOTDIR=$$tmp_dir uv run --project $(PROJECT_ABS) --group $(2) zsh -i
 endef
 
-# make/cluster_dashboard_dev_state.py (save, point, restore, delete_booting_nodes, …)
+# make/cluster_dashboard_dev_state.py (delete_booting_nodes only)
 BURLA_MAKE_PYTHON := uv run --project ./client python make/cluster_dashboard_dev_state.py
 
 .PHONY: 3.11-dev 3.12-dev 3.13-dev 3.14-dev 3.11-jupyter 3.12-jupyter 3.13-jupyter 3.14-jupyter
@@ -64,9 +64,6 @@ local-dev:
 	rm -rf ./_shared_workspace; \
 	mkdir -p ./_shared_workspace; \
 	chmod 777 ./_shared_workspace; \
-	$(BURLA_MAKE_PYTHON) save; \
-	$(BURLA_MAKE_PYTHON) point; \
-	trap '$(BURLA_MAKE_PYTHON) restore' EXIT; \
 	echo "Starting local dev"; \
 	docker network create local-burla-cluster 2>/dev/null || true; \
 	gcloud auth print-access-token > .temp_token.txt; \

--- a/makefile
+++ b/makefile
@@ -96,9 +96,6 @@ remote-dev:
 		"us-docker.pkg.dev/$${PROJECT_ID}/burla-main-service/burla-main-service:latest" \
 	); \
 	$(MAKE) __check-node-service-up-to-date && echo "" || exit 1; \
-	$(BURLA_MAKE_PYTHON) save; \
-	$(BURLA_MAKE_PYTHON) point; \
-	trap '$(BURLA_MAKE_PYTHON) restore' EXIT; \
 	docker run --rm -it \
 		--name main_service \
 		-v $(PWD)/main_service:/burla/main_service \

--- a/node_service/pyproject.toml
+++ b/node_service/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "node-service"
-version = "1.5.5"
+version = "1.5.6"
 description = ""
 authors = [{ name = "Jacob Zuliani", email = "jake@burla.dev" }]
 requires-python = ">=3.13,<4.0"

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -30,7 +30,7 @@ from starlette.requests import ClientDisconnect
 from starlette.datastructures import UploadFile
 
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 CREDENTIALS, PROJECT_ID = google.auth.default()
 BURLA_BACKEND_URL = "https://backend.burla.dev"
 

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -5,6 +5,7 @@ import inspect
 import asyncio
 import traceback
 from collections import deque
+from pathlib import Path
 from uuid import uuid4
 from time import time
 from typing import Callable
@@ -49,6 +50,12 @@ secret_client = secretmanager.SecretManagerServiceClient()
 secret_name = f"projects/{PROJECT_ID}/secrets/burla-cluster-id-token/versions/latest"
 response = secret_client.access_secret_version(request={"name": secret_name})
 CLUSTER_ID_TOKEN = response.payload.data.decode("UTF-8")
+
+# Bind-mounted into every worker container at /root/.config/burla (where
+# platformdirs resolves burla.CONFIG_PATH), so a UDF calling
+# remote_parallel_map authenticates without a prior `burla login`.
+NODE_AUTH_DIR = Path("/opt/burla/node_auth")
+NODE_AUTH_CREDENTIALS_PATH = NODE_AUTH_DIR / "burla_credentials.json"
 
 from node_service.helpers import ResultsEndpointFilter, Logger, SizedQueue
 
@@ -196,6 +203,11 @@ async def shutdown_if_idle_for_too_long(logger: Logger):
 async def lifespan(app: FastAPI):
     logger = Logger()
     await logger.log(f"Started node service v{__version__}")
+
+    # Must exist before `reboot_containers` since worker containers bind-mount
+    # this dir. Unlink guards against stale creds from a crashed prior run.
+    NODE_AUTH_DIR.mkdir(parents=True, exist_ok=True)
+    NODE_AUTH_CREDENTIALS_PATH.unlink(missing_ok=True)
 
     # In dev all the workers restart everytime I hit save (server is in "reload" mode)
     # This is annoying but you must leave it like this, otherwise stuff won't restart correctly!

--- a/node_service/src/node_service/job_endpoints.py
+++ b/node_service/src/node_service/job_endpoints.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 from datetime import datetime, timezone
 from typing import Optional
@@ -10,6 +11,7 @@ from node_service import (
     SELF,
     PROJECT_ID,
     INSTANCE_NAME,
+    NODE_AUTH_CREDENTIALS_PATH,
     get_request_json,
     get_logger,
     get_request_files,
@@ -183,6 +185,20 @@ async def execute(
         msg += f" - update the cluster to run containers with python{user_python_version}\n"
         msg += f" - update your local python version to be one of {versions}"
         return Response(msg, status_code=409)
+
+    # Must land before `load_function` so the `_process_inputs` task it
+    # spawns can never observe a missing creds file.
+    auth_token = request.headers["Authorization"].removeprefix("Bearer ").strip()
+    NODE_AUTH_CREDENTIALS_PATH.write_text(
+        json.dumps(
+            {
+                "email": request.headers["X-User-Email"],
+                "auth_token": auth_token,
+                "project_id": PROJECT_ID,
+                "cluster_dashboard_url": request_json["cluster_dashboard_url"],
+            }
+        )
+    )
 
     packages = request_json["packages"]
     if packages:

--- a/node_service/src/node_service/job_watcher.py
+++ b/node_service/src/node_service/job_watcher.py
@@ -12,7 +12,13 @@ from google.cloud.firestore_v1.async_client import AsyncClient
 from google.cloud.firestore import FieldFilter, And
 from google.cloud.firestore_v1.field_path import FieldPath
 
-from node_service import PROJECT_ID, SELF, INSTANCE_NAME, REINIT_SELF
+from node_service import (
+    PROJECT_ID,
+    SELF,
+    INSTANCE_NAME,
+    NODE_AUTH_CREDENTIALS_PATH,
+    REINIT_SELF,
+)
 from node_service.helpers import Logger, format_traceback
 from node_service.lifecycle_endpoints import reboot_containers
 
@@ -62,6 +68,8 @@ async def _input_steal_loop(async_db, session, logger, job_started_at, node_ids_
 
     should_steal = lambda: SELF["all_inputs_uploaded"] and (time() - job_started_at > 10)
     neighbor_id, neighbor_host, nodes_might_join = await get_neighbor(async_db, node_ids_expected)
+    if not (neighbor_id or nodes_might_join):
+        return
     neighbor_had_no_inputs_at = None
 
     while not SELF["job_watcher_stop_event"].is_set():
@@ -332,6 +340,8 @@ async def reinit_node(assigned_workers: list, async_db: AsyncClient):
 
 
 async def reset_workers(logger: Logger, async_db: AsyncClient):
+    # Stops idle or reassigned workers from holding creds for a finished job.
+    NODE_AUTH_CREDENTIALS_PATH.unlink(missing_ok=True)
     try:
         await asyncio.gather(*(worker.reset() for worker in SELF["workers"]))
     except Exception as e:

--- a/node_service/src/node_service/worker_client.py
+++ b/node_service/src/node_service/worker_client.py
@@ -225,6 +225,9 @@ class WorkerClient:
             "ShmSize": 16 * 1024**3,
         }
 
+        # The node_auth bind is what makes nested remote_parallel_map calls
+        # work: the node writes creds into /opt/burla/node_auth at job start
+        # and they land at burla.CONFIG_PATH inside every worker.
         if IN_LOCAL_DEV_MODE:
             host_pwd = os.environ["HOST_PWD"]
             host_home_dir = os.environ["HOST_HOME_DIR"]
@@ -235,9 +238,6 @@ class WorkerClient:
                     f"{host_home_dir}/.config/gcloud:/root/.config/gcloud",
                     f"{host_pwd}/_shared_workspace:/workspace/shared",
                     f"{worker_python_environment_dir}:/worker_service_python_env",
-                    # Lets the burla client running inside a UDF find its credentials
-                    # without the worker ever seeing CONFIG_PATH through login. The
-                    # node writes the creds file into this dir at job start.
                     f"{host_pwd}/_node_auth:/root/.config/burla",
                 ]
             )
@@ -249,7 +249,6 @@ class WorkerClient:
                 [
                     "/worker_service_python_env:/worker_service_python_env",
                     "/workspace/shared:/workspace/shared",
-                    # See local-dev branch comment above.
                     "/opt/burla/node_auth:/root/.config/burla",
                 ]
             )

--- a/node_service/src/node_service/worker_client.py
+++ b/node_service/src/node_service/worker_client.py
@@ -235,6 +235,10 @@ class WorkerClient:
                     f"{host_home_dir}/.config/gcloud:/root/.config/gcloud",
                     f"{host_pwd}/_shared_workspace:/workspace/shared",
                     f"{worker_python_environment_dir}:/worker_service_python_env",
+                    # Lets the burla client running inside a UDF find its credentials
+                    # without the worker ever seeing CONFIG_PATH through login. The
+                    # node writes the creds file into this dir at job start.
+                    f"{host_pwd}/_node_auth:/root/.config/burla",
                 ]
             )
         else:
@@ -245,6 +249,8 @@ class WorkerClient:
                 [
                     "/worker_service_python_env:/worker_service_python_env",
                     "/workspace/shared:/workspace/shared",
+                    # See local-dev branch comment above.
+                    "/opt/burla/node_auth:/root/.config/burla",
                 ]
             )
 

--- a/node_service/src/node_service/worker_server.py
+++ b/node_service/src/node_service/worker_server.py
@@ -122,6 +122,12 @@ with socket.create_server(("0.0.0.0", port)) as listener:
                 if command == b"r":
                     kill_all_other_processes()
                     loaded_function = None
+                    # Worker process persists across jobs, so burla's cached
+                    # creds from the prior job's nested RPM would otherwise
+                    # leak into the next job's user.
+                    auth_module = sys.modules.get("burla._auth")
+                    if auth_module is not None:
+                        auth_module._get_auth_info.cache_clear()
                 if command == b"i":
                     packages = pickle.loads(request_payload)
                     missing_packages = []

--- a/node_service/uv.lock
+++ b/node_service/uv.lock
@@ -755,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "node-service"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker" },


### PR DESCRIPTION
**Burla Release 1.5.6**
_"The simplest way to scale Python"_

- Nested `remote_parallel_map` calls now work: a function running on a worker can itself call `remote_parallel_map` (workers auto-authenticate, no `burla login` required inside UDFs).
- New `func_gpu` argument: allocate one GPU per function call. Supports `A100` / `A100_40G`, `A100_80G`, `H100` / `H100_80G`.
- New `image` argument: run jobs on a custom container image. When paired with `grow=True`, newly booted nodes will run that image.
- Nodes added by `grow=True` now shut down after 60s of inactivity, so burst-scaled jobs don't leave expensive hardware sitting idle.

To update run `pip install burla==1.5.6`

Made with [Cursor](https://cursor.com)