### PR TITLE
1.5.7

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "burla"
-version = "1.5.6"
+version = "1.5.7"
 description = "Easy to use cluster-compute software."
 requires-python = ">=3.11"
 dependencies = [

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -6,7 +6,7 @@ from fire import Fire
 from platformdirs import user_config_dir
 
 # needed so main_service can associate a client version with a request
-__version__ = "1.5.6"
+__version__ = "1.5.7"
 _BURLA_BACKEND_URL = "https://backend.burla.dev"
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))

--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -137,8 +137,8 @@ class ClusterClient:
                 detail["upper_version"],
                 detail["current_version"],
             )
-        if status == 409 and detail == "no_compatible_nodes":
-            raise NoCompatibleNodes()
+        if status == 409 and isinstance(detail, dict) and detail.get("error") == "no_compatible_nodes":
+            raise NoCompatibleNodes(detail)
         if status == 503 and isinstance(detail, dict) and detail.get("error") == "nodes_busy":
             raise NodesBusy()
         if status == 404:

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -286,6 +286,8 @@ class Node:
     async def _update_status(self):
         node_data = await self.client.get_node(self.instance_name)
         if not node_data:
+            # 404 means the node was DELETED (evicted from NODES_CACHE).
+            self.state = "FAILED"
             return
         self.state = node_data["status"]
         if self.state == "READY":
@@ -456,11 +458,12 @@ class Node:
         # wait until ready
         if self.state != "READY":
             await asyncio.sleep(max(0, 30 - (time() - start_time)))
-            while self.state != "READY":
+            while self.state == "BOOTING":
                 await self._update_status()
-                if self.state == "READY":
-                    break
-                await asyncio.sleep(random.uniform(2, 6))
+                if self.state == "BOOTING":
+                    await asyncio.sleep(random.uniform(2, 6))
+            if self.state != "READY":
+                return
 
         if packages:
             self.installing_packages = True

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -53,9 +53,27 @@ class AllNodesBusy(Exception):
 
 
 class NoCompatibleNodes(Exception):
-    def __init__(self):
-        message = "No compatible nodes available. Are the machines in your cluster large enough to "
-        message += "support your `func_cpu` and `func_ram` arguments?"
+    def __init__(self, detail: dict | None = None):
+        reason = detail.get("reason") if isinstance(detail, dict) else None
+        if reason == "image_mismatch":
+            requested = detail.get("requested_image")
+            available = detail.get("available_images") or []
+            message = f"\n\nNo ready nodes have the requested image `{requested}`.\n"
+            if available:
+                message += f"Images on currently-ready nodes: {available}.\n"
+            message += "Pass `grow=True` to boot nodes with this image, "
+            message += "or add it to your cluster config.\n"
+        elif reason == "gpu_mismatch":
+            requested = detail.get("requested_func_gpu")
+            available = detail.get("available_machine_types") or []
+            message = f"\n\nNo ready nodes match `func_gpu={requested!r}`.\n"
+            if available:
+                message += f"Machine types on currently-ready nodes: {available}.\n"
+            message += "Pass `grow=True` to boot a GPU node, "
+            message += "or add GPU machines to your cluster config.\n"
+        else:
+            message = "No compatible nodes available. Are the machines in your cluster large enough "
+            message += "to support your `func_cpu` and `func_ram` arguments?"
         super().__init__(message)
 
 

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -345,7 +345,9 @@ def remote_parallel_map(
         image (str, optional):
             If provided, only nodes running this container image are eligible. When
             `grow=True` and no matching nodes are available, newly booted nodes will
-            run this image. Defaults to None (no image filter).
+            run this image. Defaults to None. When `grow=True` and `image` is None,
+            defaults to the stock `python:X.Y` image matching your local Python
+            version (e.g. `python:3.12`) so new nodes can run your pickled function.
         grow (bool, optional):
             If True, adds nodes to the cluster (grows) to complete the job as quickly
             as possible. Adds up to 2560 cpus.
@@ -376,6 +378,9 @@ def remote_parallel_map(
     inputs = [(i,) if not isinstance(i, tuple) else i for i in inputs]
     if not inputs:
         return iter([]) if generator else []
+
+    if grow and image is None:
+        image = f"python:3.{sys.version_info.minor}"
 
     # TODO: rename internally
     background = detach

--- a/client/uv.lock
+++ b/client/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "burla"
-version = "1.5.6"
+version = "1.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/main_service/frontend/src/components/ClusterControls.tsx
+++ b/main_service/frontend/src/components/ClusterControls.tsx
@@ -83,7 +83,7 @@ export const ClusterControls = ({
                     highlightStart &&
                         !isOn &&
                         !isStartDisabled &&
-                        "bg-blue-700 hover:bg-blue-800 animate-pulse glow-pulse-blue ring-4 ring-blue-500 ring-offset-2 ring-offset-background transition-shadow transform transition-transform hover:scale-105"
+                        "bg-blue-700 hover:bg-blue-800 animate-pulse glow-pulse-blue ring-4 ring-blue-500 ring-offset-2 ring-offset-background transition-shadow transform transition-transform hover:scale-105",
                 )}
             >
                 {startButtonIcon}

--- a/main_service/frontend/src/pages/Index.tsx
+++ b/main_service/frontend/src/pages/Index.tsx
@@ -25,7 +25,7 @@ const Dashboard = () => {
     });
 
     const [welcomeVisible, setWelcomeVisible] = useState(
-        () => localStorage.getItem("welcomeMessageHidden") !== "true" 
+        () => localStorage.getItem("welcomeMessageHidden") !== "true",
     );
 
     useEffect(() => {
@@ -78,7 +78,7 @@ const Dashboard = () => {
                 const cpus = node.cpus ?? extractCpuCount(node.type) ?? 0;
                 return sum + cpus;
             }, 0),
-        [countedNodes]
+        [countedNodes],
     );
 
     const parseRamGB = (ram: string): number => {
@@ -116,7 +116,7 @@ const Dashboard = () => {
                 const ramStr = node.memory || parseRamDisplay(node.type);
                 return sum + parseRamGB(ramStr);
             }, 0),
-        [countedNodes]
+        [countedNodes],
     );
 
     const totalRam = totalRamGB > 0 ? `${totalRamGB}G` : "-";
@@ -237,28 +237,48 @@ const Dashboard = () => {
                                     <thead>
                                         <tr>
                                             <th className="w-8 pl-6 pr-4 py-2" />
-                                            <th className="w-24 pl-6 pr-4 py-2 text-left"><Skeleton className="h-3 w-12" /></th>
-                                            <th className="w-48 pl-6 pr-4 py-2 text-left"><Skeleton className="h-3 w-10" /></th>
-                                            <th className="w-24 pl-6 pr-4 py-2 text-left"><Skeleton className="h-3 w-12" /></th>
-                                            <th className="w-24 pl-6 pr-4 py-2 text-left"><Skeleton className="h-3 w-10" /></th>
-                                            <th className="w-24 pl-6 pr-4 py-2 text-left"><Skeleton className="h-3 w-12" /></th>
+                                            <th className="w-24 pl-6 pr-4 py-2 text-left">
+                                                <Skeleton className="h-3 w-12" />
+                                            </th>
+                                            <th className="w-48 pl-6 pr-4 py-2 text-left">
+                                                <Skeleton className="h-3 w-10" />
+                                            </th>
+                                            <th className="w-24 pl-6 pr-4 py-2 text-left">
+                                                <Skeleton className="h-3 w-12" />
+                                            </th>
+                                            <th className="w-24 pl-6 pr-4 py-2 text-left">
+                                                <Skeleton className="h-3 w-10" />
+                                            </th>
+                                            <th className="w-24 pl-6 pr-4 py-2 text-left">
+                                                <Skeleton className="h-3 w-12" />
+                                            </th>
                                             <th className="w-8 pl-6 pr-2 py-2" />
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {[...Array(3)].map((_, i) => (
                                             <tr key={i}>
-                                                <td className="w-8 pl-6 pr-4 py-2"><Skeleton className="h-4 w-4" /></td>
+                                                <td className="w-8 pl-6 pr-4 py-2">
+                                                    <Skeleton className="h-4 w-4" />
+                                                </td>
                                                 <td className="w-24 pl-6 pr-4 py-2">
                                                     <div className="flex items-center gap-2">
                                                         <Skeleton className="w-2 h-2 rounded-full" />
                                                         <Skeleton className="h-4 w-14" />
                                                     </div>
                                                 </td>
-                                                <td className="w-48 pl-6 pr-4 py-2"><Skeleton className="h-4 w-36" /></td>
-                                                <td className="w-24 pl-6 pr-4 py-2"><Skeleton className="h-4 w-8" /></td>
-                                                <td className="w-24 pl-6 pr-4 py-2"><Skeleton className="h-4 w-10" /></td>
-                                                <td className="w-24 pl-6 pr-4 py-2"><Skeleton className="h-4 w-20" /></td>
+                                                <td className="w-48 pl-6 pr-4 py-2">
+                                                    <Skeleton className="h-4 w-36" />
+                                                </td>
+                                                <td className="w-24 pl-6 pr-4 py-2">
+                                                    <Skeleton className="h-4 w-8" />
+                                                </td>
+                                                <td className="w-24 pl-6 pr-4 py-2">
+                                                    <Skeleton className="h-4 w-10" />
+                                                </td>
+                                                <td className="w-24 pl-6 pr-4 py-2">
+                                                    <Skeleton className="h-4 w-20" />
+                                                </td>
                                                 <td className="w-8 pl-6 pr-2 py-2" />
                                             </tr>
                                         ))}

--- a/main_service/frontend/src/pages/JobDetails.tsx
+++ b/main_service/frontend/src/pages/JobDetails.tsx
@@ -12,6 +12,31 @@ type JobResultStats = {
     n_failed: number;
 };
 
+type JobDoc = {
+    image?: string | null;
+    max_parallelism?: number | null;
+    func_cpu?: number | null;
+    func_ram?: number | null;
+    func_gpu?: string | null;
+};
+
+const Fact = ({
+    label,
+    value,
+    span = 1,
+}: {
+    label: string;
+    value: React.ReactNode;
+    span?: number;
+}) => (
+    <div className="min-w-0" style={{ gridColumn: `span ${span} / span ${span}` }}>
+        <div className="text-[11px] uppercase tracking-[0.08em] font-medium text-gray-500">
+            {label}
+        </div>
+        <div className="mt-1.5 text-[14.5px] leading-snug text-gray-900">{value}</div>
+    </div>
+);
+
 const JobDetails = () => {
     const { jobId } = useParams<{ jobId: string }>();
     const { jobs } = useJobs();
@@ -21,6 +46,7 @@ const JobDetails = () => {
     const [stats, setStats] = useState<JobResultStats | null>(null);
     const [isStatsLoading, setIsStatsLoading] = useState(true);
     const [statsLoadError, setStatsLoadError] = useState(false);
+    const [jobDoc, setJobDoc] = useState<JobDoc | null>(null);
     const hasCompletedInitialStatsLoadRef = useRef(false);
     const [userTimeZone, setUserTimeZone] = useState<string>(() => {
         const stored = typeof window !== "undefined" ? localStorage.getItem("userTimezone") : null;
@@ -107,6 +133,23 @@ const JobDetails = () => {
             day: "numeric",
         });
     };
+
+    const formatStartedAt = (date?: Date): string => {
+        if (!date) return "—";
+        const tz = userTimeZone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const time = date.toLocaleTimeString("en-US", {
+            timeZone: tz,
+            hour: "numeric",
+            minute: "2-digit",
+            hour12: true,
+        });
+        const monthDay = date.toLocaleDateString("en-US", {
+            timeZone: tz,
+            month: "short",
+            day: "numeric",
+        });
+        return `${time}, ${monthDay}`;
+    };
     const getStatusBadgeClass = (status: string | null) => {
         const statusClasses: Record<string, string> = {
             PENDING: "border-slate-300 bg-slate-50 text-slate-700",
@@ -170,6 +213,18 @@ const JobDetails = () => {
         setStatsLoadError(false);
         setIsStatsLoading(true);
         hasCompletedInitialStatsLoadRef.current = false;
+    }, [jobId]);
+
+    useEffect(() => {
+        if (!jobId) return;
+        setJobDoc(null);
+        const controller = new AbortController();
+        (async () => {
+            const res = await fetch(`/v1/jobs/${jobId}`, { signal: controller.signal });
+            if (!res.ok) return;
+            setJobDoc(await res.json());
+        })().catch(() => {});
+        return () => controller.abort();
     }, [jobId]);
 
     useEffect(() => {
@@ -289,63 +344,88 @@ const JobDetails = () => {
     return (
         <div className="flex flex-col flex-1 min-h-0 px-12 pt-0">
             <div className="max-w-6xl mx-auto w-full flex flex-col flex-1 min-h-0">
-                <div className="mb-3 rounded-lg border border-gray-200 bg-white px-4 py-3">
-                    <div className="flex flex-row items-start justify-between mb-2">
-                        <h1 className="text-2xl font-bold mt-[-4px] text-primary">
-                            <button
-                                onClick={() => navigate("/jobs")}
-                                className="hover:underline underline-offset-2 decoration-[0.5px] transition text-inherit"
-                            >
-                                Jobs
-                            </button>
-                            <span className="mx-2 text-inherit">›</span>
-                            <span className="text-inherit">{job.id}</span>
-                        </h1>
-                        <Button
-                            variant="destructive"
-                            size="lg"
-                            className="h-11 rounded-lg"
-                            onClick={stopJob}
-                            disabled={
-                                isStopping || (job?.status !== "RUNNING" && job?.status !== "PENDING")
-                            }
-                        >
-                            <PowerOff className="mr-2 h-4 w-4" />
-                            Stop
-                        </Button>
-                    </div>
-
-                    <div className="flex flex-row items-center text-[14.5px] text-gray-800">
-                        <div className="flex items-center space-x-6">
-                            <div className="flex items-center space-x-2">
+                <div className="mb-3 rounded-lg border border-gray-200 bg-white px-6 py-5">
+                    <div className="flex flex-row items-start justify-between gap-4">
+                        <div className="min-w-0">
+                            <div className="flex items-center gap-3 flex-wrap">
+                                <h1 className="text-[24px] font-semibold tracking-tight text-gray-900 truncate">
+                                    {job.function_name ?? "Unknown"}
+                                </h1>
                                 <span
-                                    className={`inline-flex items-center gap-2 rounded-full border px-3 py-0.5 text-[14.5px] font-normal ${getStatusBadgeClass(job.status)}`}
+                                    className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[13.5px] font-medium ${getStatusBadgeClass(job.status)}`}
                                 >
-                                    <span className={`h-2.5 w-2.5 rounded-full ${getStatusDotClass(job.status)}`} />
-                                    <span>
-                                    {job.status?.toUpperCase() || "UNKNOWN"}
-                                    </span>
+                                    <span className={`h-2 w-2 rounded-full ${getStatusDotClass(job.status)}`} />
+                                    <span>{(job.status ?? "UNKNOWN").toLowerCase().replace(/^./, c => c.toUpperCase())}</span>
                                 </span>
                             </div>
-                            <div className="flex items-baseline">
-                                <span>Function:</span>
-                                <span className="ml-2">{job.function_name ?? "Unknown"}</span>
-                            </div>
-                            <div className="flex items-baseline">
-                                <span>Started At:</span>
-                                <span className="ml-2 flex items-baseline">
-                                    <span className="tabular-nums">
-                                        {formatStartedAtTime(job.started_at)}
-                                    </span>
-                                    <span className="ml-1">
-                                        {formatStartedAtWeekday(job.started_at)}
-                                    </span>
-                                    <span className="ml-1">
-                                        {formatStartedAtMonthDay(job.started_at)}
-                                    </span>
-                                </span>
+                            <div className="mt-1.5 font-mono text-[13px] text-gray-500 truncate">
+                                {job.id}
                             </div>
                         </div>
+                        {(() => {
+                            const canStop = job?.status === "RUNNING" || job?.status === "PENDING";
+                            return (
+                                <Button
+                                    variant={canStop ? "destructive" : "outline"}
+                                    size="sm"
+                                    className="h-9 rounded-md shrink-0"
+                                    onClick={stopJob}
+                                    disabled={isStopping || !canStop}
+                                >
+                                    <PowerOff className="mr-2 h-3.5 w-3.5" />
+                                    Stop
+                                </Button>
+                            );
+                        })()}
+                    </div>
+
+                    <div className="mt-5 pt-5 border-t border-gray-100 grid grid-cols-2 sm:grid-cols-4 gap-x-8 gap-y-5">
+                        <Fact label="Function" value={job.function_name ?? "Unknown"} />
+                        <Fact
+                            label="Started"
+                            value={
+                                <span className="tabular-nums">
+                                    {formatStartedAt(job.started_at)}
+                                </span>
+                            }
+                        />
+                        <Fact
+                            label="Image"
+                            span={2}
+                            value={
+                                <span className="font-mono text-[13px] break-all">
+                                    {jobDoc?.image ?? (jobDoc ? "default" : "—")}
+                                </span>
+                            }
+                        />
+                        <Fact
+                            label="Max parallelism"
+                            value={
+                                <span className="tabular-nums">
+                                    {jobDoc?.max_parallelism ?? "—"}
+                                </span>
+                            }
+                        />
+                        <Fact
+                            label="Function CPU"
+                            value={
+                                <span className="tabular-nums">
+                                    {jobDoc?.func_cpu != null ? `${jobDoc.func_cpu} vCPU` : "—"}
+                                </span>
+                            }
+                        />
+                        <Fact
+                            label="Function RAM"
+                            value={
+                                <span className="tabular-nums">
+                                    {jobDoc?.func_ram != null ? `${jobDoc.func_ram} GB` : "—"}
+                                </span>
+                            }
+                        />
+                        <Fact
+                            label="Function GPU"
+                            value={jobDoc?.func_gpu ?? (jobDoc ? "None" : "—")}
+                        />
                     </div>
                 </div>
 

--- a/main_service/frontend/src/pages/JobDetails.tsx
+++ b/main_service/frontend/src/pages/JobDetails.tsx
@@ -379,8 +379,7 @@ const JobDetails = () => {
                         })()}
                     </div>
 
-                    <div className="mt-5 pt-5 border-t border-gray-100 grid grid-cols-2 sm:grid-cols-4 gap-x-8 gap-y-5">
-                        <Fact label="Function" value={job.function_name ?? "Unknown"} />
+                    <div className="mt-5 pt-5 border-t border-gray-100 grid grid-cols-2 sm:grid-cols-3 gap-x-8 gap-y-5">
                         <Fact
                             label="Started"
                             value={
@@ -391,7 +390,6 @@ const JobDetails = () => {
                         />
                         <Fact
                             label="Image"
-                            span={2}
                             value={
                                 <span className="font-mono text-[13px] break-all">
                                     {jobDoc?.image ?? (jobDoc ? "default" : "—")}

--- a/main_service/frontend/vite.config.ts
+++ b/main_service/frontend/vite.config.ts
@@ -8,6 +8,11 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": "http://localhost:5001",
+      "/v1": "http://localhost:5001",
+      "/v3": "http://localhost:5001",
+    },
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(
     Boolean,

--- a/main_service/makefile
+++ b/main_service/makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 .SILENT:
 
-BURLA_VERSION = 1.5.6
+BURLA_VERSION = 1.5.7
 WEBSERVICE_NAME = burla-main-service
 PYTHON_MODULE_NAME = main_service
 

--- a/main_service/pyproject.toml
+++ b/main_service/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "main_service"
-version = "1.5.6"
+version = "1.5.7"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>, Joseph Perry <joe@burla.dev>"]
 packages = [{include = "main_service", from = "src"}]

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -454,6 +454,19 @@ async def validate_requests(request: Request, call_next):
       - use client_id to get auth info, set auth cookie -> redirect here again but with auth cookie
       - here again with auth cookie -> access granted
     """
+    # Local-dev bypass: the auth middleware normally validates every request
+    # against backend.burla.dev, which requires a Google/Microsoft login. In
+    # local-dev there is no real user flow, so stamp a fake session and let
+    # everything through. NEVER runs in prod because IN_LOCAL_DEV_MODE is only
+    # set by the `make local-dev` target.
+    if IN_LOCAL_DEV_MODE:
+        if not request.session.get("X-User-Email"):
+            request.session["X-User-Email"] = "local-dev@burla.dev"
+            request.session["Authorization"] = "Bearer local-dev"
+            request.session["name"] = "Local Dev"
+            request.session["profile_pic"] = ""
+        return await call_next(request)
+
     # Allow unauthenticated access for storage stub endpoints and resumable signing during development
     # These are non-privileged helpers used by the storage UI.
     if request.url.path.startswith("/api/sf/") or request.url.path == "/signed-resumable":

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -25,8 +25,8 @@ from jinja2 import Environment, FileSystemLoader
 os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
-CURRENT_BURLA_VERSION = "1.5.6"
-MIN_COMPATIBLE_CLIENT_VERSION = "1.5.6"
+CURRENT_BURLA_VERSION = "1.5.7"
+MIN_COMPATIBLE_CLIENT_VERSION = "1.5.7"
 
 # In this mode EVERYTHING runs locally in docker containers.
 # possible modes: local-dev-mode (everything local), remote-dev-mode (only main-service local), prod

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -26,7 +26,7 @@ os.environ["GRPC_VERBOSITY"] = "ERROR"
 os.environ["GLOG_minloglevel"] = "2"
 
 CURRENT_BURLA_VERSION = "1.5.6"
-MIN_COMPATIBLE_CLIENT_VERSION = "1.5.5"
+MIN_COMPATIBLE_CLIENT_VERSION = "1.5.6"
 
 # In this mode EVERYTHING runs locally in docker containers.
 # possible modes: local-dev-mode (everything local), remote-dev-mode (only main-service local), prod

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -445,6 +445,7 @@ async def start_job(
         "burla_client_version": client_version,
         "user_python_version": body["user_python_version"],
         "target_parallelism": target_parallelism,
+        "max_parallelism": max_parallelism,
         "user": auth_headers["X-User-Email"],
         "function_name": body["function_name"],
         "function_size_gb": float(body.get("function_size_gb") or 0.0),

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -132,29 +132,36 @@ def _select_ready_nodes_from_cache(
     requested per-function resources, up to `max_parallelism` total slots.
     When `image` is set, only nodes running that container are eligible.
     When `func_gpu` is set, only nodes on a matching GPU family are eligible.
-    Returns (selected_nodes, total_parallelism, ready_nodes).
+
+    Returns `(selected, total_parallelism, ready_after_filters,
+    ready_after_image, unfiltered_ready)`. The three list-tail values let
+    `start_job` tell "cluster is empty", "ready nodes exist but none have
+    the image", "ready nodes have the image but none match the GPU", and
+    "ready nodes match image+GPU but are too small" apart.
     """
     machine_prefix = gpu_machine_prefix(func_gpu)
     with _nodes_cache_lock:
         all_nodes = list(NODES_CACHE.values())
-    ready_nodes = [
+    unfiltered_ready = [
         n for n in all_nodes
         if n.get("status") == "READY" and not n.get("reserved_for_job")
     ]
+    ready_after_image = unfiltered_ready
     if image:
-        ready_nodes = [
-            n for n in ready_nodes
+        ready_after_image = [
+            n for n in unfiltered_ready
             if image in [c["image"] for c in n.get("containers") or []]
         ]
+    ready_after_filters = ready_after_image
     if machine_prefix:
-        ready_nodes = [
-            n for n in ready_nodes
+        ready_after_filters = [
+            n for n in ready_after_image
             if (n.get("machine_type") or "").startswith(machine_prefix)
         ]
 
     selected = []
     total_parallelism = 0
-    for node_data in ready_nodes:
+    for node_data in ready_after_filters:
         deficit = max_parallelism - total_parallelism
         if deficit <= 0:
             break
@@ -172,7 +179,13 @@ def _select_ready_nodes_from_cache(
             }
         )
         total_parallelism += node_parallelism
-    return selected, total_parallelism, ready_nodes
+    return (
+        selected,
+        total_parallelism,
+        ready_after_filters,
+        ready_after_image,
+        unfiltered_ready,
+    )
 
 
 def _grow_if_needed(
@@ -293,11 +306,17 @@ async def start_job(
         }
 
     Error responses:
-        409 {"detail": "version_mismatch", "lower_version", "upper_version",
-             "current_version"}  - client is outside compatible range
-        409 {"detail": "no_compatible_nodes"}                 - ready nodes exist but none fit
-        503 {"detail": "nodes_busy",                           - no ready nodes, some booting /
-             "booting_count", "running_count"}                   running; client should retry
+        409 {"detail": {"error": "version_mismatch", ...}}    - client is outside compatible range
+        409 {"detail": {"error": "no_compatible_nodes",
+             "reason": "image_mismatch"
+                     | "gpu_mismatch"
+                     | "insufficient_capacity",
+             "requested_image", "requested_func_gpu",
+             "available_images"?, "available_machine_types"?}}
+                                                              - ready nodes exist but none fit
+        503 {"detail": {"error": "nodes_busy",
+             "booting_count", "running_count"}}               - no ready nodes, some booting /
+                                                                running; client should retry
         404 {"detail": "no_nodes"}                            - empty cluster, grow=False
     """
     body = await request.json()
@@ -335,7 +354,13 @@ async def start_job(
         raise HTTPException(status_code=400, detail=str(error))
 
     # --- select from cached ready nodes ---
-    ready, target_parallelism, all_ready = _select_ready_nodes_from_cache(
+    (
+        ready,
+        target_parallelism,
+        all_ready,
+        ready_after_image,
+        unfiltered_ready,
+    ) = _select_ready_nodes_from_cache(
         func_cpu=func_cpu,
         func_ram=func_ram,
         max_parallelism=max_parallelism,
@@ -358,10 +383,35 @@ async def start_job(
                     "running_count": running_count,
                 },
             )
-        if all_ready:
-            # Ready nodes exist but none have enough capacity for this UDF.
-            raise HTTPException(status_code=409, detail="no_compatible_nodes")
-        raise HTTPException(status_code=404, detail="no_nodes")
+        if not unfiltered_ready:
+            raise HTTPException(status_code=404, detail="no_nodes")
+        # Ready nodes exist but none are selectable for this job. Pick the
+        # most specific reason so the client can tell the user what to do.
+        if image and not ready_after_image:
+            reason = "image_mismatch"
+        elif func_gpu and ready_after_image and not all_ready:
+            reason = "gpu_mismatch"
+        else:
+            reason = "insufficient_capacity"
+        detail: dict = {
+            "error": "no_compatible_nodes",
+            "reason": reason,
+            "requested_image": image,
+            "requested_func_gpu": func_gpu,
+        }
+        if reason == "image_mismatch":
+            detail["available_images"] = sorted({
+                c["image"]
+                for n in unfiltered_ready
+                for c in (n.get("containers") or [])
+            })
+        elif reason == "gpu_mismatch":
+            detail["available_machine_types"] = sorted({
+                n.get("machine_type")
+                for n in ready_after_image
+                if n.get("machine_type")
+            })
+        raise HTTPException(status_code=409, detail=detail)
 
     # --- grow, if requested and short on capacity ---
     booting_nodes: list[dict] = []

--- a/main_service/src/main_service/endpoints/cluster_lifecycle.py
+++ b/main_service/src/main_service/endpoints/cluster_lifecycle.py
@@ -219,7 +219,9 @@ def _mark_running_jobs_with_lifecycle_event(event: str, message: str):
     # /results (see Node._gather_results), so write it on the same update as the
     # status change. Writes happen before VM teardown in _shutdown_cluster, so
     # the doc is authoritative if a node vanishes mid-poll.
-    extra = {"cluster_restarted": True} if event == "cluster_restarted" else {"cluster_shutdown": True}
+    extra = (
+        {"cluster_restarted": True} if event == "cluster_restarted" else {"cluster_shutdown": True}
+    )
     for job_snapshot in running_jobs:
         job_ref = job_snapshot.reference
         job_ref.collection("logs").add(log_doc)
@@ -264,5 +266,3 @@ async def shutdown_cluster(
 
     duration = time() - start
     logger.log(f"Shut down after {duration//60}m {duration%60}s")
-
-

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -79,7 +79,7 @@ def zones_supporting_machine_type(
     name_filter = f"name={machine_type_name}"
     request = AggregatedListMachineTypesRequest(project=PROJECT_ID, filter=name_filter)
     client = machine_types_client or MachineTypesClient()
-    zone_generator = client.aggregated_list(request=request)
+    zone_generator = client.aggregated_list(request=request, retry=GCE_TRANSIENT_RETRY)
     for zone, matches in zone_generator:
         if matches.machine_types and zone.startswith(f"zones/{region_name}"):
             yield zone.split("/")[1]

--- a/main_service/src/main_service/static/index.html
+++ b/main_service/src/main_service/static/index.html
@@ -10,8 +10,8 @@
         />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="apple-touch-icon" href="/favicon.png" />
-      <script type="module" crossorigin src="/assets/index-evPHRWKp.js"></script>
-      <link rel="stylesheet" crossorigin href="/assets/index-DzYx-ufe.css">
+      <script type="module" crossorigin src="/assets/index-DgPMT7G7.js"></script>
+      <link rel="stylesheet" crossorigin href="/assets/index-qYLv-t6f.css">
     </head>
 
     <body>

--- a/main_service/src/main_service/static/index.html
+++ b/main_service/src/main_service/static/index.html
@@ -10,8 +10,8 @@
         />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="apple-touch-icon" href="/favicon.png" />
-      <script type="module" crossorigin src="/assets/index-DgPMT7G7.js"></script>
-      <link rel="stylesheet" crossorigin href="/assets/index-qYLv-t6f.css">
+      <script type="module" crossorigin src="/assets/index-BzcmJfRt.js"></script>
+      <link rel="stylesheet" crossorigin href="/assets/index-Y6-k41P4.css">
     </head>
 
     <body>

--- a/node_service/pyproject.toml
+++ b/node_service/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "node-service"
-version = "1.5.6"
+version = "1.5.7"
 description = ""
 authors = [{ name = "Jacob Zuliani", email = "jake@burla.dev" }]
 requires-python = ">=3.13,<4.0"

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -31,7 +31,7 @@ from starlette.requests import ClientDisconnect
 from starlette.datastructures import UploadFile
 
 
-__version__ = "1.5.6"
+__version__ = "1.5.7"
 CREDENTIALS, PROJECT_ID = google.auth.default()
 BURLA_BACKEND_URL = "https://backend.burla.dev"
 

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -93,6 +93,7 @@ def REINIT_SELF(SELF):
     SELF["active_client_request_count"] = 0
     SELF["last_client_activity_timestamp"] = time()
     SELF["reserved_for_job"] = None
+    SELF["watch_reservation_task"] = None
     SELF["SHUTTING_DOWN"] = False
 
 
@@ -235,6 +236,12 @@ async def on_job_start(scope, first_event):
     SELF["RUNNING"] = True
     SELF["current_job"] = job_id
     SELF["reserved_for_job"] = None
+    # `_watch_reservation` is obsolete once assignment arrives - cancel so its
+    # firestore snapshot listener is torn down without writing a redundant clear
+    # (the node_doc.update below already clears `reserved_for_job`).
+    watch_task = SELF.get("watch_reservation_task")
+    if watch_task and not watch_task.done():
+        watch_task.cancel()
     node_doc = ASYNC_DB.collection("nodes").document(INSTANCE_NAME)
     update_fields = {"status": "RUNNING", "current_job": job_id, "reserved_for_job": None}
     SELF["on_job_start_task"] = asyncio.create_task(node_doc.update(update_fields))

--- a/node_service/src/node_service/job_watcher.py
+++ b/node_service/src/node_service/job_watcher.py
@@ -267,12 +267,11 @@ async def _job_watcher(
         job_completed = False
         all_uploaded = SELF["all_inputs_uploaded"]
         all_inputs_processed = all_uploaded and input_queue_empty and all_workers_idle
-        all_local_work_complete = all_inputs_processed and SELF["results_queue"].empty()
-        if all_local_work_complete and client_disconnected:
+        if all_inputs_processed and client_disconnected:
             node_docs = await node_docs_collection.get()
             result_count = sum(doc.to_dict()["current_num_results"] for doc in node_docs)
             job_completed = n_inputs == result_count
-        elif all_local_work_complete:
+        elif all_inputs_processed and SELF["results_queue"].empty():
             job_completed = (await job_doc.get()).to_dict()["client_has_all_results"]
         if job_completed or JOB_FAILED or JOB_CANCELED:
             steal_task.cancel()

--- a/node_service/src/node_service/lifecycle_endpoints.py
+++ b/node_service/src/node_service/lifecycle_endpoints.py
@@ -227,7 +227,6 @@ def _schedule_container_removal(
 
 
 RESERVATION_ASSIGNMENT_TIMEOUT_SEC = 60
-RESERVATION_POLL_INTERVAL_SEC = 2
 
 
 async def _watch_reservation(job_id: str):
@@ -237,14 +236,27 @@ async def _watch_reservation(job_id: str):
     arrives within `RESERVATION_ASSIGNMENT_TIMEOUT_SEC`. In either case, clear the reservation
     so another job can use this node.
     """
-    job_ref = ASYNC_DB.collection("jobs").document(job_id)
-    deadline = time() + RESERVATION_ASSIGNMENT_TIMEOUT_SEC
+    sync_db = firestore.Client(project=PROJECT_ID, database="burla")
+    loop = asyncio.get_running_loop()
+    reservation_ended = asyncio.Event()
 
-    while time() < deadline and SELF["reserved_for_job"] == job_id:
-        status = (await job_ref.get()).to_dict()["status"]
-        if status != "RUNNING":
-            break
-        await asyncio.sleep(RESERVATION_POLL_INTERVAL_SEC)
+    def _on_job_snapshot(doc_snapshot, changes, read_time):
+        for change in changes:
+            data = change.document.to_dict()
+            if data and data.get("status") != "RUNNING":
+                loop.call_soon_threadsafe(reservation_ended.set)
+                return
+
+    watch = sync_db.collection("jobs").document(job_id).on_snapshot(_on_job_snapshot)
+    try:
+        await asyncio.wait_for(
+            reservation_ended.wait(),
+            timeout=RESERVATION_ASSIGNMENT_TIMEOUT_SEC,
+        )
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        pass
+    finally:
+        watch.unsubscribe()
 
     if SELF["reserved_for_job"] == job_id:
         SELF["reserved_for_job"] = None
@@ -375,7 +387,9 @@ async def reboot_containers(
         node_doc.update({"status": "READY"})
 
         if SELF["reserved_for_job"]:
-            asyncio.create_task(_watch_reservation(SELF["reserved_for_job"]))
+            SELF["watch_reservation_task"] = asyncio.create_task(
+                _watch_reservation(SELF["reserved_for_job"])
+            )
 
     except Exception as parent_exception:
         SELF["FAILED"] = True

--- a/node_service/uv.lock
+++ b/node_service/uv.lock
@@ -755,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "node-service"
-version = "1.5.6"
+version = "1.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker" },


### PR DESCRIPTION
**Burla Release 1.5.7**
_"The simplest way to scale Python"_

- Clearer "no compatible nodes" errors: the client now tells you whether `image`, `func_gpu`, or `func_cpu`/`func_ram` was the mismatch, and prints what's actually available on ready nodes.
- `grow=True` without an `image` arg now defaults to a stock `python:X.Y` image matching your local Python version, so newly booted nodes can always deserialize your function.
- Redesigned job details page shows each job's image, max parallelism, and per-function cpu/ram/gpu.
- Assorted reliability fixes around node booting and reservation cleanup.

To update run `pip install burla==1.5.7`

Made with [Cursor](https://cursor.com)