### PR TITLE
fix(node): don't leak is_booting to firestore

### DIFF
--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -142,9 +142,17 @@ def _select_ready_nodes_from_cache(
     machine_prefix = gpu_machine_prefix(func_gpu)
     with _nodes_cache_lock:
         all_nodes = list(NODES_CACHE.values())
+    # A node can have status=READY while still carrying is_booting=True in the
+    # cache (e.g. the doc was written before the boot-finalize update landed,
+    # or a prior job left it in an inconsistent state). Assigning work to such
+    # a node makes `/assign` return HTTP 500, which surfaces on the client as:
+    #   Exception: Failed to assign <node>: 500
+    # Filter them here so only fully-ready nodes are handed out.
     unfiltered_ready = [
         n for n in all_nodes
-        if n.get("status") == "READY" and not n.get("reserved_for_job")
+        if n.get("status") == "READY"
+        and not n.get("reserved_for_job")
+        and not n.get("is_booting")
     ]
     ready_after_image = unfiltered_ready
     if image:
@@ -488,6 +496,13 @@ async def cluster_state():
     ready_nodes = []
     for data in nodes_snapshot:
         status = data.get("status")
+        # A node doc with status=READY and is_booting=True is still in the
+        # process of finalizing boot. Counting it as BOOTING matches how
+        # `_select_ready_nodes_from_cache` treats it (unassignable), and
+        # prevents clients from thinking capacity is available when it is not.
+        if data.get("is_booting") and status in ("BOOTING", "READY"):
+            booting_count += 1
+            continue
         if status == "BOOTING":
             booting_count += 1
         elif status == "RUNNING":

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -142,17 +142,9 @@ def _select_ready_nodes_from_cache(
     machine_prefix = gpu_machine_prefix(func_gpu)
     with _nodes_cache_lock:
         all_nodes = list(NODES_CACHE.values())
-    # A node can have status=READY while still carrying is_booting=True in the
-    # cache (e.g. the doc was written before the boot-finalize update landed,
-    # or a prior job left it in an inconsistent state). Assigning work to such
-    # a node makes `/assign` return HTTP 500, which surfaces on the client as:
-    #   Exception: Failed to assign <node>: 500
-    # Filter them here so only fully-ready nodes are handed out.
     unfiltered_ready = [
         n for n in all_nodes
-        if n.get("status") == "READY"
-        and not n.get("reserved_for_job")
-        and not n.get("is_booting")
+        if n.get("status") == "READY" and not n.get("reserved_for_job")
     ]
     ready_after_image = unfiltered_ready
     if image:
@@ -496,13 +488,6 @@ async def cluster_state():
     ready_nodes = []
     for data in nodes_snapshot:
         status = data.get("status")
-        # A node doc with status=READY and is_booting=True is still in the
-        # process of finalizing boot. Counting it as BOOTING matches how
-        # `_select_ready_nodes_from_cache` treats it (unassignable), and
-        # prevents clients from thinking capacity is available when it is not.
-        if data.get("is_booting") and status in ("BOOTING", "READY"):
-            booting_count += 1
-            continue
         if status == "BOOTING":
             booting_count += 1
         elif status == "RUNNING":

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -185,6 +185,7 @@ class Node:
             "machine_types_client",
             "node_ref",
             "auth_headers",
+            "is_booting",
         ]
         current_state = {k: v for k, v in current_state.items() if k not in attrs_to_not_save}
         self.node_ref.set(current_state)
@@ -212,10 +213,7 @@ class Node:
             self.delete()
             raise e
 
-        # `is_booting=True` was persisted by the initial node_ref.set(self.__dict__)
-        # above and is cleared nowhere else; clear it here so the doc reflects the
-        # post-boot state instead of staying stuck on the initial value forever.
-        self.node_ref.update(dict(host=self.host, zone=self.zone, is_booting=False))
+        self.node_ref.update(dict(host=self.host, zone=self.zone))  # node svc marks itself as ready
         self.is_booting = False
         return self
 

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -212,11 +212,9 @@ class Node:
             self.delete()
             raise e
 
-        # Persist is_booting=False alongside host/zone so the firestore doc (and
-        # NODES_CACHE) stop reporting a fully-booted node as "is_booting=True".
-        # Without this, a stale is_booting=True can linger forever in cache and
-        # cause `_select_ready_nodes_from_cache` (and any downstream filter) to
-        # incorrectly treat the node as assignable-but-still-booting.
+        # `is_booting=True` was persisted by the initial node_ref.set(self.__dict__)
+        # above and is cleared nowhere else; clear it here so the doc reflects the
+        # post-boot state instead of staying stuck on the initial value forever.
         self.node_ref.update(dict(host=self.host, zone=self.zone, is_booting=False))
         self.is_booting = False
         return self

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -212,7 +212,12 @@ class Node:
             self.delete()
             raise e
 
-        self.node_ref.update(dict(host=self.host, zone=self.zone))  # node svc marks itself as ready
+        # Persist is_booting=False alongside host/zone so the firestore doc (and
+        # NODES_CACHE) stop reporting a fully-booted node as "is_booting=True".
+        # Without this, a stale is_booting=True can linger forever in cache and
+        # cause `_select_ready_nodes_from_cache` (and any downstream filter) to
+        # incorrectly treat the node as assignable-but-still-booting.
+        self.node_ref.update(dict(host=self.host, zone=self.zone, is_booting=False))
         self.is_booting = False
         return self
 


### PR DESCRIPTION
## Problem

`Node.start()` writes the initial node doc at `main_service/src/main_service/node.py:190` via `self.node_ref.set(dict(self.__dict__))`. At that point `self.is_booting = True` from line 161, so `is_booting=True` lands in firestore. Nothing else ever clears it - the field is only referenced in `main_service/src/main_service/node.py` as an in-memory attribute (verified by grep). Every `nodes/{id}` doc in firestore ends up reporting `is_booting=True` forever, including for nodes that have long since transitioned to READY.

No consumer reads `is_booting` from firestore. The attribute is still useful in-memory - `Node.status()` uses it at lines 243/252, and the `from_firestore_snapshot` constructor at line 116 reconstructs it from `status == \"BOOTING\"`, not from the firestore field itself. So writing it at all is pointless; it just produces a permanently-stale value on every node doc.

## Fix

Add `\"is_booting\"` to the existing `attrs_to_not_save` list at `main_service/src/main_service/node.py:181-188`. The initial `dict(self.__dict__)` dump already filters out a handful of other non-serializable / irrelevant attributes (`db`, `logger`, `instance_client`, etc.); `is_booting` belongs in the same list for the same reason. The in-memory attribute continues to work exactly as before.

```diff
         attrs_to_not_save = [
             \"db\",
             \"logger\",
             \"instance_client\",
             \"machine_types_client\",
             \"node_ref\",
             \"auth_headers\",
+            \"is_booting\",
         ]
```

## Scope changes

This PR originally:

1. added a `is_booting=True` filter in `_select_ready_nodes_from_cache`,
2. counted such nodes as BOOTING in `cluster_state`, and
3. wrote `is_booting=False` on boot finalize.

All three assumed `is_booting` was a field worth maintaining in firestore. On review, nothing reads it from firestore, so the cleaner fix is to stop writing it. Both `endpoints/client.py` and the original `node.py:215` update are back to `main`.

If a `HTTP 500 on /assign` symptom reproduces (the original motivation for the filter), the right follow-up is to diagnose the real cause in the scheduler or `/assign` handler, not to gate on a correlated-but-unused field.

## Test plan

- [ ] Boot a cluster, confirm every `nodes/{id}` doc in firestore **does not contain** an `is_booting` key.
- [ ] `Node.status()` behaviour unchanged (still uses in-memory `self.is_booting`).
- [ ] `Node.from_firestore_snapshot()` still reconstructs `is_booting` correctly from `status`.