### PR TITLE
fix(errors): stop blaming "the cluster may have been restarted" for UDF hard-exits

### DIFF
--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -557,7 +557,7 @@ class Node:
                     error_info = pickle.loads(result_pkl)
                     if error_info.get("is_infrastructure_error"):
                         msg = f"Worker on node {self.instance_name} failed "
-                        msg += "(the cluster may have been restarted):\n\n"
+                        msg += f"while executing input index {input_index}:\n\n"
                         msg += error_info["traceback_str"]
                         raise NodeDisconnected(self, await self._failure_message(msg))
                     traceback = Traceback.from_dict(error_info["traceback_dict"]).as_traceback()

--- a/node_service/src/node_service/worker_client.py
+++ b/node_service/src/node_service/worker_client.py
@@ -379,7 +379,15 @@ class WorkerClient:
                 await self._log_container_failure()
                 raise RuntimeError("\n\nWorker container stopped unexpectedly.\n")
             await asyncio.sleep(0.1)
-        raise RuntimeError("\n\nWorker connection closed unexpectedly.\n")
+        # Naming the likely causes points users at their own UDF instead of a
+        # suspected cluster or network issue.
+        msg = (
+            "\n\nWorker process ended unexpectedly while the container was still healthy.\n"
+            "This usually means the user function called `os._exit`, `sys.exit`, raised\n"
+            "`SystemExit`/`KeyboardInterrupt`, or crashed a C extension (segfault / OOM of\n"
+            "the worker subprocess specifically). The cluster itself is fine.\n"
+        )
+        raise RuntimeError(msg)
 
     async def _read_response(self):
         try:


### PR DESCRIPTION
## Why

When a UDF hard-exits the worker (e.g. `os._exit(137)`), the client prints:

```
NodeDisconnected: Worker on node burla-node-xxx failed
(the cluster may have been restarted):
...
```

**The cluster wasn't restarted.** The user's own function killed the worker. The current message sends users chasing the wrong thing — re-logging in, filing support tickets, assuming Burla is flaky — when the fix is in their own code.

## What changes

Two tiny edits, 12 lines added across two files.

### 1. `node_service/worker_client.py`

When the worker's IPC socket closes but the container is still healthy, the `RuntimeError` used to say:

```
Worker connection closed unexpectedly.
```

Now it names the real causes and clears Burla's name:

```
Worker process ended unexpectedly while the container was still healthy.
This usually means the user function called `os._exit`, `sys.exit`, raised
`SystemExit`/`KeyboardInterrupt`, or crashed a C extension (segfault / OOM of
the worker subprocess specifically). The cluster itself is fine.
```

### 2. `client/src/burla/_node.py`

The `is_infrastructure_error` branch drops the "cluster may have been restarted" speculation. Replaces it with the **input index** the worker was processing — already in scope (loop variable), and the single most useful piece of debug info for this failure mode:

```diff
-msg += "(the cluster may have been restarted):\n\n"
+msg += f"while executing input index {input_index}:\n\n"
```

## Not overlapping with #162

#162 handles `KeyboardInterrupt` / `SystemExit` via the worker server's **error-report path** — the worker catches and reports them. This PR targets the other branch: when the worker dies before it can report anything, so the client only sees an infrastructure error. Different code path, separate concern.

## Test plan

- [ ] `remote_parallel_map(lambda x: os._exit(137), [0])` — error names `os._exit` / `sys.exit`, includes the input index, no "cluster may have been restarted".
- [ ] Actually restart the cluster mid-job — `ClusterRestarted` path still fires (unchanged code path).
- [ ] Real OOMKill — `_worker_oom_error` still fires first (fires before the changed line).

## History

Rebased onto current `main` after the error-surface work landed (#171, #165, #164, #167, #174, etc.). Only the two substantive changes above remain; the earlier version of this branch was from before any of that and had a lot of unrelated stale diff.

---

Made with [Cursor](https://cursor.com)