### PR TITLE
feat(auto-install): scan UDF body AST so lazy imports work

### DIFF
--- a/client/src/burla/_helpers.py
+++ b/client/src/burla/_helpers.py
@@ -1,7 +1,10 @@
+import ast
+import inspect
 import os
 import sys
 import signal
 import subprocess
+import textwrap
 import types
 from typing import Union
 from threading import Event
@@ -153,6 +156,20 @@ def _scan_sys_modules():
     return custom_module_names, package_module_names, has_custom_modules
 
 
+def _imports_inside_function_body(function_) -> set:
+    try:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(function_)))
+    except (OSError, TypeError, SyntaxError):
+        return set()
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.add(node.module.split(".")[0])
+    return names
+
+
 def get_modules_required_on_remote(function_):
     """
     Returns all package modules if custom user-defined modules exist.
@@ -174,5 +191,6 @@ def get_modules_required_on_remote(function_):
             if is_module or has_module:
                 module_name = var.__name__ if is_module else var.__module__
                 function_module_names.add(module_name.split(".")[0])
+        function_module_names |= _imports_inside_function_body(function_)
         package_module_names = package_module_names.intersection(function_module_names)
     return custom_module_names, package_module_names


### PR DESCRIPTION
## Why

Burla's auto-install only sees packages that are in `function_.__globals__` at submission time. Lazy imports inside UDFs — a common, legitimate pattern — slip past it:

```python
def worker(x):
    import numpy as np
    ...

remote_parallel_map(worker, inputs)
```

On a fresh `python:3.12` worker this fails immediately with `ModuleNotFoundError: No module named 'numpy'`, because `numpy` was never imported at module level on the driver.

## What changes

`client/_helpers.py` adds `_imports_inside_function_body(function_)` — uses `inspect.getsource` + `ast.walk` to collect top-level module names from `import X` / `from X import Y` nodes inside the function body (and any nested `def` / `lambda`). `get_modules_required_on_remote` unions the returned set into `function_module_names` before intersecting with the installed-package set, so lazy imports now ship to the worker.

Introspection failures (C-defined callables, REPL-defined functions, unparsable source) and relative imports return an empty set, so this never regresses existing behavior.

## Test plan

- [ ] UDF with `import numpy as np` in its body on a fresh `python:3.12` worker — runs instead of raising `ModuleNotFoundError`.
- [ ] Lambdas and C-defined callables still submit without errors.
- [ ] Relative-import UDFs still use the custom-module path.

---

Made with [Cursor](https://cursor.com)