### PR TITLE
fix(errors): attach burla_input_index to UDF exceptions

### DIFF
--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -529,11 +529,10 @@ class Node:
                     log_error = RemoteParallelMapReporter.log_user_function_error_async
                     await log_error(self.job_id, self.session)
                     exc = error_info["exception"].with_traceback(traceback)
-                    # A batch of 1000 inputs + a bare `ValueError` is useless to
-                    # debug without knowing which input triggered it. Attach the
-                    # index as an attribute (programmatic access) and, on 3.11+,
-                    # as an inline note (visible in the default traceback).
-                    # Guarded because some exception types forbid attr writes.
+                    # Preserve the failing input index on the exception so callers
+                    # can identify the bad item in a large batch; add a 3.11+
+                    # note so it is visible in the default traceback. Guarded
+                    # because some exception types disallow attribute writes.
                     try:
                         exc.burla_input_index = input_index
                         if hasattr(exc, "add_note"):

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -528,7 +528,19 @@ class Node:
                     self.udf_error_event.set()
                     log_error = RemoteParallelMapReporter.log_user_function_error_async
                     await log_error(self.job_id, self.session)
-                    raise error_info["exception"].with_traceback(traceback)
+                    exc = error_info["exception"].with_traceback(traceback)
+                    # A batch of 1000 inputs + a bare `ValueError` is useless to
+                    # debug without knowing which input triggered it. Attach the
+                    # index as an attribute (programmatic access) and, on 3.11+,
+                    # as an inline note (visible in the default traceback).
+                    # Guarded because some exception types forbid attr writes.
+                    try:
+                        exc.burla_input_index = input_index
+                        if hasattr(exc, "add_note"):
+                            exc.add_note(f"[burla] failed on input index {input_index}")
+                    except Exception:
+                        pass
+                    raise exc
                 else:
                     return_values.append(cloudpickle.loads(result_pkl))
 

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -368,6 +368,17 @@ def remote_parallel_map(
             A list containing the objects returned by `function_` in no particular order.
             If `generator=True`, returns a generator that yields results as they are produced.
 
+    Raises:
+        Any exception raised by `function_` on a worker is re-raised here on the
+        client. The raised exception has ``exc.burla_input_index`` set to the
+        index (in ``inputs``) of the item that triggered the failure, so you
+        can identify which input broke without wrapping your UDF in try/except:
+
+            try:
+                results = remote_parallel_map(fn, inputs)
+            except Exception as e:
+                bad_input = inputs[e.burla_input_index]
+
     See Also:
         For more info see our overview: https://docs.burla.dev/overview
         or API-Reference: https://docs.burla.dev/api-reference


### PR DESCRIPTION
## Problem

When a UDF raises inside `remote_parallel_map`, the client re-raises the worker's exception verbatim. A batch of 1000 inputs followed by a bare `ValueError: bad geometry` tells the user nothing about *which* of the 1000 inputs triggered it. The only workaround today is wrapping the entire UDF body in try/except just to include the input in the error message.

## Fix

The input index is already known at the re-raise site (`input_index` loop variable in `Node.execute_job`) — it just wasn't surfaced. This PR attaches it to the exception object:

- `exc.burla_input_index` — the index into `inputs` that triggered the failure.
- On Python 3.11+, also calls `exc.add_note(...)` so the index shows up in the default traceback without any extra code.

Both calls are guarded with try/except because a few exception types disallow attribute writes; if attaching fails the original exception still propagates unchanged.

## Usage

```python
try:
    results = remote_parallel_map(score_parcel, parcels)
except Exception as e:
    bad_parcel = parcels[e.burla_input_index]
    # reproduce locally, fix the edge case, re-run
```

## Scope / compatibility

- Purely additive. Callers that catch bare `Exception` and never touch `burla_input_index` see no behaviour change.
- Change is confined to the UDF-error path in `client/_node.py`. The `is_infrastructure_error` branch is untouched.
- Docstring of `remote_parallel_map` gains a `Raises:` section documenting the new attribute.

## Test plan

- [ ] Submit a batch where input index 12 raises and confirm `e.burla_input_index == 12`.
- [ ] Confirm on Python 3.11+ the default traceback ends with `[burla] failed on input index 12`.
- [ ] Confirm callers that don't reference the attribute see identical behaviour to before.