### PR TITLE
Handle UDF-raised KeyboardInterrupt / SystemExit end-to-end

### DIFF
--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -501,7 +501,7 @@ def remote_parallel_map(
                         func_gpu=func_gpu,
                     )
                 )
-            except Exception:
+            except BaseException:
                 execute_job.exc_info = sys.exc_info()
 
         t = Thread(target=execute_job, daemon=True)
@@ -533,7 +533,7 @@ def remote_parallel_map(
 
         return _output_generator() if generator else list(_output_generator())
 
-    except Exception as e:
+    except BaseException as e:
         if spinner:
             spinner.stop()
 

--- a/node_service/src/node_service/worker_client.py
+++ b/node_service/src/node_service/worker_client.py
@@ -428,7 +428,9 @@ class WorkerClient:
             try:
                 result_pkl = await self.call_function(input_index, input_pkl)
                 result = (input_index, False, result_pkl)
-            except Exception as error:
+            except asyncio.CancelledError:
+                raise
+            except BaseException as error:
                 if self.log_writer is not None:
                     await self.log_writer.write_error(input_index, self._traceback_string(error))
                 result = (input_index, True, self._serialize_error(error))

--- a/node_service/src/node_service/worker_server.py
+++ b/node_service/src/node_service/worker_server.py
@@ -164,7 +164,7 @@ with socket.create_server(("0.0.0.0", port)) as listener:
                     finally:
                         print(f"{LOG_END_MARKER_PREFIX}{input_index}", flush=True)
                     response_payload = cloudpickle.dumps(return_value)
-            except Exception as e:
+            except BaseException as e:
                 tb_dict = Traceback(e.__traceback__).to_dict()
                 response_payload = pickle.dumps(
                     {"error_info": dict(type=type(e), exception=e, traceback_dict=tb_dict)}


### PR DESCRIPTION
## Problem

Jack ran a UDF called `_raise_keyboardinterrupt` on `jack-burla` and got this instead of a `KeyboardInterrupt`:

```
burla._node.NodeDisconnected: Worker on node burla-node-9fd28449 failed (the cluster may have been restarted):

...
  File ".../node_service/worker_client.py", line 386, in _read_response
    status = await self.reader.readexactly(1)
asyncio.exceptions.IncompleteReadError: 0 bytes read on a total of 1 expected bytes

During handling of the above exception, another exception occurred:

  File ".../node_service/worker_client.py", line 429, in _process_inputs
    result_pkl = await self.call_function(input_index, input_pkl)
  File ".../node_service/worker_client.py", line 382, in _raise_if_worker_failed
    raise RuntimeError("\n\nWorker connection closed unexpectedly.\n")
RuntimeError: Worker connection closed unexpectedly.
```

## Root cause

`KeyboardInterrupt` (and `SystemExit`) inherit from `BaseException`, **not** `Exception`. Four `except Exception` clauses along the worker -> node -> client path all miss them:

1. `worker_server.py` UDF dispatcher -> KeyboardInterrupt escapes the try/except, Python process dies, TCP socket closes.
2. `_raise_if_worker_failed` on the node sees the container PID 1 (a shell loop that restarts Python every 100ms) still running and falls through to `RuntimeError(\"Worker connection closed unexpectedly.\")` after 1 second of polling.
3. `_process_inputs` catches that RuntimeError and serializes it with `is_infrastructure_error: True`.
4. Client turns it into `NodeDisconnected`, suggesting the cluster may have been restarted.

So a UDF that just does `raise KeyboardInterrupt` looks indistinguishable from an actual cluster outage.

## Fix

Four one-line changes (plus one `except asyncio.CancelledError: raise` guard) that let a UDF-raised `BaseException` flow through the same path as a regular UDF `Exception`:

- `node_service/src/node_service/worker_server.py` - catch `BaseException` in the UDF dispatcher so the worker stays alive and reports it like any other error.
- `node_service/src/node_service/worker_client.py::_process_inputs` - catch `BaseException` coming back from `_read_response`, with `except asyncio.CancelledError: raise` first so `reset()`'s `process_inputs_task.cancel()` still works (`CancelledError` is also a `BaseException`).
- `client/src/burla/_remote_parallel_map.py` thread wrapper - catch `BaseException` so a UDF-originated `KeyboardInterrupt` out of `asyncio.run` is stored in `exc_info` and re-raised to the main thread instead of the daemon thread dying silently and the main thread blocking forever on `return_queue.get()`.
- `client/src/burla/_remote_parallel_map.py` outer cleanup block - catch `BaseException` so the spinner is stopped and the job doc is marked `FAILED` on the way out, instead of leaving the spinner spinning and the job stuck in `RUNNING`.

## Why this is safe

- User Ctrl+C does not reach these clauses as `KeyboardInterrupt`. `install_signal_handlers` in `client/src/burla/_helpers.py` replaces the default handlers for SIGINT / SIGTERM / SIGHUP / SIGQUIT (POSIX) and SIGINT / SIGBREAK (NT) with one that sets `terminal_cancel_event` and never raises.
- `KeyboardInterrupt` is already in `EXEC_TYPES_TO_NOT_ALERT`, and `udf_error_event` is set before the exception is re-raised in `_node.py`, so no spurious telemetry alert fires.
- The `except asyncio.CancelledError: raise` preserves the existing cancellation path in `_process_inputs`.
- Same fixes also cover `sys.exit()` / `SystemExit` raised from a UDF, and `BaseExceptionGroup` from a UDF using `asyncio.TaskGroup`.

## After

A UDF like `def _raise_keyboardinterrupt(x): raise KeyboardInterrupt` surfaces as a clean `KeyboardInterrupt` traceback ending at the user's line, with the spinner stopped and the job doc marked `FAILED`.

## Test plan

- [ ] Run a UDF that does `raise KeyboardInterrupt` with `remote_parallel_map` and confirm the user sees a real `KeyboardInterrupt` traceback (not `NodeDisconnected`).
- [ ] Run a UDF that does `sys.exit(1)` and confirm the user sees `SystemExit` (not `NodeDisconnected`).
- [ ] Run a normal UDF that raises `ValueError` and confirm nothing regressed.
- [ ] Hit Ctrl+C during a running `remote_parallel_map` and confirm the job cancels cleanly via `terminal_cancel_event` (not via the new `except BaseException` path).
- [ ] Confirm spinner stops cleanly and job doc shows `FAILED` after the `KeyboardInterrupt` case.


Made with [Cursor](https://cursor.com)