### PR TITLE
Include the node's last error in NodeDisconnected

### DIFF
--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -192,6 +192,19 @@ class ClusterClient:
     async def get_node(self, node_id: str) -> Optional[dict]:
         return await self._request("GET", f"/v1/cluster/nodes/{node_id}")
 
+    async def get_node_fail_reason(self, node_id: str) -> Optional[str]:
+        """Best-guess failure reason from the node's log subcollection, or
+        None if no logs / network failure. Only called on the failure
+        path so this is never in a tight loop."""
+        try:
+            result = await self._request("GET", f"/v1/cluster/nodes/{node_id}/fail_reason")
+        except Exception:
+            return None
+        if not result:
+            return None
+        reason = (result.get("reason") or "").strip()
+        return reason or None
+
     async def fail_node(self, node_id: str, reason: str) -> None:
         await self._request(
             "POST",

--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -193,9 +193,8 @@ class ClusterClient:
         return await self._request("GET", f"/v1/cluster/nodes/{node_id}")
 
     async def get_node_fail_reason(self, node_id: str) -> Optional[str]:
-        """Best-guess failure reason from the node's log subcollection, or
-        None if no logs / network failure. Only called on the failure
-        path so this is never in a tight loop."""
+        # Enrichment-only on the failure path: swallow network/5xx errors
+        # so the lookup itself can't break the caller's NodeDisconnected.
         try:
             result = await self._request("GET", f"/v1/cluster/nodes/{node_id}/fail_reason")
         except Exception:

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -232,6 +232,19 @@ class Node:
     def _node_silence_timeout_message(self, action: str):
         return f"Node {self.instance_name} has not replied for over 2 minutes while {action}.\n"
 
+    async def _failure_message(self, base_msg: str | None = None) -> str:
+        """Enrich a `NodeDisconnected` message with the node's own error log
+        when one exists, so the user sees the root cause (e.g. a failed
+        `docker pull`) instead of just "Node X failed during job." Returns
+        the base message unchanged if the node has no error-looking log or
+        the lookup itself fails - the fallback must never make the error
+        worse than today."""
+        base = base_msg or f"Node {self.instance_name} failed during job."
+        reason = await self.client.get_node_fail_reason(self.instance_name)
+        if not reason:
+            return base
+        return f"{base}\n\nLast error reported by the node:\n{reason}"
+
     def _empty_node_results(self):
         return {
             "results": [],
@@ -401,11 +414,11 @@ class Node:
                     if job_doc and job_doc.get("status") == "CANCELED":
                         raise JobCanceled("Job canceled from dashboard.")
                     msg = f"Node {self.instance_name} disconnected while transmitting results.\n"
-                    raise NodeDisconnected(self, msg)
+                    raise NodeDisconnected(self, await self._failure_message(msg))
         except NETWORK_ERROR_TYPES:
             if self._node_silence_timeout_exceeded():
                 msg = self._node_silence_timeout_message("returning results")
-                raise NodeDisconnected(self, msg)
+                raise NodeDisconnected(self, await self._failure_message(msg))
             return self._empty_node_results()
 
         if node_results.get("cluster_shutdown"):
@@ -523,7 +536,7 @@ class Node:
                         msg = f"Worker on node {self.instance_name} failed "
                         msg += "(the cluster may have been restarted):\n\n"
                         msg += error_info["traceback_str"]
-                        raise NodeDisconnected(self, msg)
+                        raise NodeDisconnected(self, await self._failure_message(msg))
                     traceback = Traceback.from_dict(error_info["traceback_dict"]).as_traceback()
                     self.udf_error_event.set()
                     log_error = RemoteParallelMapReporter.log_user_function_error_async

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -233,14 +233,9 @@ class Node:
         return f"Node {self.instance_name} has not replied for over 2 minutes while {action}.\n"
 
     async def _failure_message(self, base_msg: str | None = None) -> str:
-        """Enrich a `NodeDisconnected` message with the node's own error log
-        when one exists, so the user sees the root cause (e.g. a failed
-        `docker pull`) instead of just "Node X failed during job." Returns
-        the base message unchanged if the node has no error-looking log or
-        the lookup itself fails - the fallback must never make the error
-        worse than today."""
         base = base_msg or f"Node {self.instance_name} failed during job."
         reason = await self.client.get_node_fail_reason(self.instance_name)
+        # Fall back to base so enrichment can't produce a worse error than before.
         if not reason:
             return base
         return f"{base}\n\nLast error reported by the node:\n{reason}"

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -245,7 +245,8 @@ async def _execute_job(
 
             for task, node in zip(node_tasks, nodes):
                 exception = task.exception() if task.done() else None
-                exception = NodeDisconnected(node) if node.state == "FAILED" else exception
+                if node.state == "FAILED":
+                    exception = NodeDisconnected(node, await node._failure_message())
                 if exception:
                     # Authoritative check via main_service: if main_service has
                     # already written a lifecycle signal on the job doc, raise

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -514,29 +514,15 @@ async def get_cluster_node(node_id: str):
     return data
 
 
-# Tokens that mean "this log is explaining a failure". Earliest log matching
-# any of these is usually the root cause; later logs (e.g. "Startup script
-# failed!", timeout tracebacks) are cascades of the same failure.
+# Earliest log matching one of these is usually the root cause; later logs
+# ("Startup script failed!", timeout tracebacks) are cascades.
 _FAIL_LOG_TOKENS = ("Error", "error", "failed", "Traceback", "Exception")
 
 
+# 404 (rather than "return the most recent log") lets the client distinguish
+# real failure explanations from innocuous info logs and fall back cleanly.
 @router.get("/v1/cluster/nodes/{node_id}/fail_reason")
 async def get_node_fail_reason(node_id: str):
-    """
-    Best-guess failure message for a FAILED node, so the client can
-    include it in `NodeDisconnected` instead of just the instance name.
-
-    Returns the earliest log entry whose message contains a failure
-    token - that's almost always the root cause. Cascades like
-    "Startup script failed!" and timeout tracebacks come after and are
-    skipped in favor of the first real error.
-
-    Reads the node's `logs` subcollection directly. Cold path - only hit
-    once per failed job, not on the polling loop - so a Firestore round
-    trip here is fine. 404s if there's no error-looking log so callers
-    can tell "genuine failure explanation" apart from "node just has
-    some info logs".
-    """
     logs_ref = ASYNC_DB.collection("nodes").document(node_id).collection("logs")
     async for doc in logs_ref.order_by("ts").stream():
         msg = ((doc.to_dict() or {}).get("msg") or "").strip()

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -514,6 +514,37 @@ async def get_cluster_node(node_id: str):
     return data
 
 
+# Tokens that mean "this log is explaining a failure". Earliest log matching
+# any of these is usually the root cause; later logs (e.g. "Startup script
+# failed!", timeout tracebacks) are cascades of the same failure.
+_FAIL_LOG_TOKENS = ("Error", "error", "failed", "Traceback", "Exception")
+
+
+@router.get("/v1/cluster/nodes/{node_id}/fail_reason")
+async def get_node_fail_reason(node_id: str):
+    """
+    Best-guess failure message for a FAILED node, so the client can
+    include it in `NodeDisconnected` instead of just the instance name.
+
+    Returns the earliest log entry whose message contains a failure
+    token - that's almost always the root cause. Cascades like
+    "Startup script failed!" and timeout tracebacks come after and are
+    skipped in favor of the first real error.
+
+    Reads the node's `logs` subcollection directly. Cold path - only hit
+    once per failed job, not on the polling loop - so a Firestore round
+    trip here is fine. 404s if there's no error-looking log so callers
+    can tell "genuine failure explanation" apart from "node just has
+    some info logs".
+    """
+    logs_ref = ASYNC_DB.collection("nodes").document(node_id).collection("logs")
+    async for doc in logs_ref.order_by("ts").stream():
+        msg = ((doc.to_dict() or {}).get("msg") or "").strip()
+        if msg and any(tok in msg for tok in _FAIL_LOG_TOKENS):
+            return {"reason": msg}
+    raise HTTPException(status_code=404, detail="no failure log for node")
+
+
 @router.post("/v1/cluster/nodes/{node_id}/fail")
 async def fail_cluster_node(
     node_id: str,

--- a/main_service/uv.lock
+++ b/main_service/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"

--- a/main_service/uv.lock
+++ b/main_service/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"


### PR DESCRIPTION
## Problem
When a node transitions to `FAILED` mid-job, the client raises

    NodeDisconnected: Node burla-node-<id> failed during job.

with no indication of *why*. The real cause (e.g. a bad `image=` arg that
fails `docker pull`) is already written to `nodes/{id}/logs` but nothing
propagates it to the client. Users have to open the dashboard to find out
anything useful.

Concrete example from `jack-burla` today, job `_identity-f9xkXhylSaqC`:
user passed `image="this-image-does-not-exist:v999"`, node logs show
`docker pull ... pull access denied`, client saw only "failed during job".

## Solution
- New endpoint `GET /v1/cluster/nodes/{node_id}/fail_reason` in
  `main_service` that reads the `nodes/{id}/logs` subcollection and
  returns the earliest log whose message contains an error token
  (`Error`, `error`, `failed`, `Traceback`, `Exception`). That's almost
  always the root cause; later cascades like "Startup script failed!"
  and timeout tracebacks are skipped in favor of the first real error.
  404 if no error-looking log is found so callers can tell a real
  explanation apart from innocuous info logs.
- `get_node_fail_reason` wrapper in `client/_cluster_client.py` that
  swallows its own failures and returns `None`.
- New `Node._failure_message(base_msg=None)` helper that appends the
  looked-up reason under "Last error reported by the node:". If the
  lookup returns nothing it just returns `base_msg` (or the legacy
  default) - the error surface can never get worse than today.
- The four `NodeDisconnected` raise sites (one in
  `_remote_parallel_map.py`, three in `_node.py`) now route through
  `_failure_message`.

## Test plan
- [ ] `make local-dev` + `remote_parallel_map(lambda x: x, [1], image="bad-image:v1", grow=True)` - NodeDisconnected message includes the docker pull error.
- [ ] Happy-path grow-cluster E2E still passes.
- [ ] Manually kill a worker container mid-job - NodeDisconnected surfaces the worker traceback instead of the bare message.

Made with [Cursor](https://cursor.com)