### PR TITLE
Bail out of Node.start boot-wait as soon as Firestore says FAILED

### DIFF
--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -196,11 +196,20 @@ class Node:
                 self.__start_svc_in_vm(disk_image=self.disk_image, disk_size=self.disk_size)
 
             start = time()
+            last_fs_check = start
             status = self.status()
             while status not in ("READY", "RUNNING"):
                 sleep(1)
                 booting_too_long = (time() - start) > NODE_BOOT_TIMEOUT
                 status = self.status()
+
+                # Startup-script trap writes FAILED to Firestore directly,
+                # bypassing the HTTP path self.status() checks.
+                if status == "BOOTING" and (time() - last_fs_check) >= 2:
+                    last_fs_check = time()
+                    fs_status = (self.node_ref.get().to_dict() or {}).get("status")
+                    if fs_status == "FAILED":
+                        status = "FAILED"
 
                 if status == "FAILED" or booting_too_long:
                     msg = f"Node {self.instance_name} Failed to start! (timeout={booting_too_long})"


### PR DESCRIPTION
## Problem
When a node's VM startup fails (e.g. `docker pull` on a bad user image),
the startup-script `handle_error` trap PATCHes `status: FAILED` on the
node doc in Firestore and deletes the VM. But `main_service.Node.start`'s
boot-wait loop doesn't read Firestore - it pings `{host}/` via HTTP, and
on `ConnectionError` it returns `"BOOTING"` (because `is_booting=True`).

Result: the wait loop spins for the full `NODE_BOOT_TIMEOUT = 600s`
before raising, even though Firestore already holds the definitive
FAILED status within seconds of boot failure. Wastes a slot in the
background-task pool, pollutes the node's log subcollection with a
bogus "timeout=True" traceback, and - if the main_service snapshot
listener is ever slow - becomes the client-visible delay too.

Observed today in `jack-burla`, node `burla-node-9dd551f8`: startup
script marked FAILED at `ended_at=1776825900`, Node.start timed out
at `1776826478` - 578s wasted.

## Solution
In the wait loop at `main_service/src/main_service/node.py`, when
`self.status()` (HTTP) reports `BOOTING`, also read `self.node_ref`
from Firestore. If that doc shows FAILED, treat the node as FAILED.
`Node.status()` keeps its HTTP-only contract; the cross-check lives
only in the wait loop. One extra Firestore get per second per booting
node while booting - background task, not on the client request path.

## Test plan
- [ ] Boot a node with a bad `image=` via `grow=True` in local-dev; confirm Node.start raises "Failed to start!" within ~2s of the docker pull error (previously ~600s).
- [ ] Normal boot path still reaches READY/RUNNING (no extra latency added to the hot loop).
- [ ] Grow-cluster E2E still passes.

Made with [Cursor](https://cursor.com)