### PR TITLE
fix(client): tolerate cold-boot 404s on booting nodes

### DIFF
--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -20,6 +20,7 @@ from burla._reporting import RemoteParallelMapReporter
 
 
 NODE_SILENCE_TIMEOUT_SECONDS = 2 * 60
+NODE_BOOT_DEADLINE_SEC = 10 * 60
 LOGIN_TIMEOUT_SEC = 10
 MAX_INPUT_SIZE_BYTES = 1_000_000 * 200  # 200MB
 MAX_CHUNK_SIZE_BYTES = 1_000_000 * 2  # 2MB
@@ -220,6 +221,7 @@ class Node:
         self.installing_packages = False
         self.result_count = 0
         self.last_reply_timestamp = time()
+        self.started_booting_at = time()
         self.auth_headers = get_auth_headers()
         self.spinner_compatible_print = lambda msg: spinner.write(msg) if spinner else print(msg)
 
@@ -285,8 +287,12 @@ class Node:
 
     async def _update_status(self):
         node_data = await self.client.get_node(self.instance_name)
-        if not node_data:
-            # 404 means the node was DELETED (evicted from NODES_CACHE).
+        if node_data is None:
+            # A 404 during BOOTING can race main_service's background write of
+            # the initial firestore doc — the instance_name came back from
+            # /v1/jobs/{id}/start before the doc landed. Not a real eviction.
+            if self.state == "BOOTING":
+                return
             self.state = "FAILED"
             return
         self.state = node_data["status"]
@@ -461,6 +467,9 @@ class Node:
             while self.state == "BOOTING":
                 await self._update_status()
                 if self.state == "BOOTING":
+                    if (time() - self.started_booting_at) > NODE_BOOT_DEADLINE_SEC:
+                        self.state = "FAILED"
+                        break
                     await asyncio.sleep(random.uniform(2, 6))
             if self.state != "READY":
                 return


### PR DESCRIPTION
## Problem
`remote_parallel_map(..., grow=True, image=<heavy>)` fails on a cold cluster with the opaque "Zero nodes working..." fallback (or, depending on timing, `NodeDisconnected`).

Trace: `main_service` returns an instance_name from `POST /v1/jobs/{id}/start` synchronously, but the background `_start_nodes` task writes the initial BOOTING firestore doc a moment later. During that window `GET /v1/cluster/nodes/{id}` returns 404. The client's `_update_status` currently maps any 404 to `state=\"FAILED\"`, killing the job before the node even exists.

Seen today on \`jack-burla\`, job \`_identity-ZaHgkxJ5Rc-t\`.

## Solution
- \`_update_status\` now distinguishes \"evicted\" from \"not yet written\": a 404 on a node the client still thinks is BOOTING is a no-op (keep polling).
- Add \`NODE_BOOT_DEADLINE_SEC = 10 * 60\` and \`Node.started_booting_at\` so the poll loop in \`execute_job\` gives up cleanly if the server never gets the node to READY.

No server-side changes; no new public surface.

## Test plan
- [ ] \`pytest client/tests/test.py\` passes locally.
- [ ] On a cold cluster, \`remote_parallel_map(lambda x: x, [0], grow=True, image=\"jakezuliani/burla-embedder:latest\")\` completes on the first call (previously needed a \`_warmup_cluster\` dummy call first).
- [ ] Point \`image=\` at a nonexistent image; confirm the client raises after ~10 minutes via the new deadline, not after 30s.

Made with [Cursor](https://cursor.com)