### PR TITLE
fix(client): informative JobStalled error in place of opaque fallback

### DIFF
--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -52,6 +52,14 @@ class AllNodesBusy(Exception):
         super().__init__("All nodes are busy, please try again later.")
 
 
+class JobStalled(Exception):
+    """
+    Raised by `_execute_job` when every node task has finished but we still
+    don't have all results. Replaces a bare `Exception` fallback; the message
+    lists each node's terminal state so users can see which nodes died.
+    """
+
+
 class NoCompatibleNodes(Exception):
     def __init__(self, detail: dict | None = None):
         reason = detail.get("reason") if isinstance(detail, dict) else None

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -32,6 +32,7 @@ from burla._node import (
     ClusterRestarted,
     ClusterShutdown,
     JobCanceled,
+    JobStalled,
     MainServiceTimeout,
     Node,
     NoCompatibleNodes,
@@ -70,6 +71,7 @@ EXEC_TYPES_TO_NOT_ALERT = [
     AllNodesBusy,
     NoCompatibleNodes,
     JobCanceled,
+    JobStalled,
     ClusterRestarted,
     ClusterShutdown,
     VersionMismatch,
@@ -295,7 +297,16 @@ async def _execute_job(
 
             total_result_count = sum(node.result_count for node in nodes)
             if all([task.done() for task in node_tasks]) and total_result_count < n_inputs:
-                raise Exception("Zero nodes working on job and we have not received all results!")
+                summary = "\n".join(
+                    f"  {n.instance_name}  state={n.state}  result_count={n.result_count}"
+                    for n in nodes
+                )
+                msg = (
+                    f"Job ended before all results were received "
+                    f"({total_result_count}/{n_inputs}).\n"
+                    f"Final node states:\n{summary}\n"
+                )
+                raise JobStalled(msg)
 
         job_success_telemetry_task = create_task(
             reporter.log_job_success_telemetry(time() - start_time)


### PR DESCRIPTION
## Problem
When every node task finishes but we still don't have all results, the client raises

    Exception: Zero nodes working on job and we have not received all results!

This fires in several real situations - all grown nodes getting 409/503 on assignment (image / python version mismatch, shutting down), the `NODE_BOOT_DEADLINE_SEC` timeout added in the sibling cold-boot PR (#165), etc. - and tells the user nothing useful. It's also a bare `Exception` with no class hierarchy so callers can't catch it.

## Solution
- New `JobStalled(Exception)` in `client/src/burla/_node.py`.
- Replace the bare raise with a `JobStalled` that lists every node's terminal state and `result_count`, plus the missing-results count.
- Add `JobStalled` to `EXEC_TYPES_TO_NOT_ALERT` so clean "node refused" outcomes don't page Sentry.

Example output:

    Job ended before all results were received (0/10).
    Final node states:
      burla-node-a1b2c3d4  state=REMOVED  result_count=0
      burla-node-e5f6g7h8  state=FAILED   result_count=0

## Coordination with #163
#163 adds `Node._failure_message(base_msg)` that appends the node's latest log line. Once #163 merges, the per-node summary here can be upgraded to call that helper on FAILED nodes so the summary carries the root-cause error line. As shipped here the plain `state=<state>` output is still strictly better than the current opaque exception.

## Test plan
- [ ] \`pytest client/tests/test.py\` passes locally.
- [ ] \`remote_parallel_map(lambda x: x, [0], grow=True, image=\"python:3.11\")\` from a Python-3.12 client - the grown node 409s on assignment; client raises \`JobStalled\` naming the REMOVED node.
- [ ] Pair with #165: the \`NODE_BOOT_DEADLINE_SEC\` path now surfaces as \`JobStalled\` with the offending node \`state=FAILED\`.

Made with [Cursor](https://cursor.com)