### PR TITLE
fix: differentiate parallelism=0 / empty-workers / version-mismatch in 409

### DIFF
--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -255,6 +255,16 @@ def _grow_if_needed(
             n_nodes_to_add = math.ceil(num_cpus_to_add / cpu_per_node)
             node_machine_types = [configured_machine_type] * n_nodes_to_add
 
+    # A machine_type whose capacity is 0 for this func_cpu/func_ram would boot a
+    # node that can't run a single call, and the client would then send
+    # parallelism=0 to it, producing a misleading 409 from the node.
+    node_machine_types = [
+        mt for mt in node_machine_types
+        if parallelism_capacity(mt, func_cpu, func_ram) > 0
+    ]
+    if not node_machine_types:
+        return []
+
     node_instance_names = [f"burla-node-{uuid4().hex[:8]}" for _ in node_machine_types]
     containers_override = [{"image": image}] if image else None
 

--- a/node_service/src/node_service/job_endpoints.py
+++ b/node_service/src/node_service/job_endpoints.py
@@ -178,13 +178,23 @@ async def execute(
         node_doc = async_db.collection("nodes").document(INSTANCE_NAME)
         await node_doc.update({"status": "READY", "current_job": None})
 
-        msg = "No compatible containers.\n"
-        msg += f"User is running python version {user_python_version}, "
-        versions = list(set([e.python_version for e in SELF["workers"]]))
-        msg += f"containers in the cluster are running: {', '.join(versions)}.\n"
-        msg += "To fix this you can either:\n"
-        msg += f" - update the cluster to run containers with python{user_python_version}\n"
-        msg += f" - update your local python version to be one of {versions}"
+        requested_parallelism = request_json["parallelism"]
+        if requested_parallelism <= 0:
+            msg = (
+                f"Node was assigned {requested_parallelism} parallelism slots. "
+                "This usually means the requested func_cpu/func_ram is larger than "
+                "this machine_type can fit."
+            )
+        elif not SELF["workers"]:
+            msg = "Node has no workers loaded yet (still booting)."
+        else:
+            versions = list(set([e.python_version for e in SELF["workers"]]))
+            msg = "No compatible containers.\n"
+            msg += f"User is running python version {user_python_version}, "
+            msg += f"containers in the cluster are running: {', '.join(versions)}.\n"
+            msg += "To fix this you can either:\n"
+            msg += f" - update the cluster to run containers with python{user_python_version}\n"
+            msg += f" - update your local python version to be one of {versions}"
         return Response(msg, status_code=409)
 
     # Must land before `load_function` so the `_process_inputs` task it


### PR DESCRIPTION
## Issue
When the node-service's `/jobs/{id}` assign endpoint finds no workers to assign, it emits a 409 that always blames Python-version mismatch. Observed on `jack-burla` 2026-04-21 at 02:44: 13 freshly-booted nodes returned

```
User is running python version 3.12, containers in the cluster are running: 3.12.
```

The versions match. The real cause was `parallelism=0` in the request body - the node reached the assign loop with nothing to assign to, but the error message said the opposite.

## Evidence
From GCP Logging (`jack-burla`, job `_identity-llJubg9aQlij`):
- 13 × `WARNING non-2xx status response: 409: No compatible containers. User is running python version 3.12, containers in the cluster are running: 3.12.` between 02:44:10 and 02:44:22 UTC across 13 different nodes.
- All nodes had successfully logged `Done booting 80 workers, burla-node-<id> is READY!` seconds earlier, so `SELF["workers"]` was populated with 80 workers whose `python_version == "3.12"`.

## Root cause
[`node_service/src/node_service/job_endpoints.py`](../blob/main/node_service/src/node_service/job_endpoints.py#L151-L188). The assign loop:

```python
for worker in SELF["workers"]:
    correct_python_version = worker.python_version == user_python_version
    need_more_parallelism = future_parallelism < request_json["parallelism"]
    if correct_python_version and need_more_parallelism:
        workers_to_assign.append(worker)
        future_parallelism += 1
    else:
        workers_to_leave_idle.append(worker)
```

When `request_json["parallelism"] == 0`, `need_more_parallelism` is False on iteration 0 and stays False forever, so every worker goes to `workers_to_leave_idle` and the `if not workers_to_assign` branch fires - but its message only describes the python-version case.

A matching upstream cause in [`main_service/endpoints/client.py::_grow_if_needed`](../blob/main/main_service/src/main_service/endpoints/client.py): booting-node entries return `target_parallelism=parallelism_capacity(machine_type, func_cpu, func_ram)`, and that can be 0 when the packed machine is too small for the requested per-call resources (e.g. `func_cpu=120` forces a packer remainder onto a smaller machine). `_select_ready_nodes_from_cache` already skips ready nodes with capacity 0; the grow path was missing the same guard.

## Fix
- `node_service/job_endpoints.py`: split the 409 message into three cases:
  - `parallelism <= 0` -> `Node was assigned 0 parallelism slots. This usually means the requested func_cpu/func_ram is larger than this machine_type can fit.`
  - `SELF["workers"]` empty -> `Node has no workers loaded yet (still booting).`
  - else (existing) -> the python-version mismatch message.
- `main_service/endpoints/client.py::_grow_if_needed`: filter `node_machine_types` to only machines with `parallelism_capacity > 0` before booting. Return `[]` if none remain, matching the function's existing \"nothing to do\" early returns.

## Test plan
- [ ] `remote_parallel_map(lambda x: x, [0], func_cpu=120, grow=True)` from a cold cluster - previously produced a misleading python-version 409; now either raises `NoNodes` (if no machine can fit) or succeeds on an n4-standard-80.
- [ ] `remote_parallel_map(lambda x: x, [0], grow=True)` from a Python 3.11 client against a cluster pinned to `python:3.12` - still produces the original python-version mismatch message (unchanged path).
- [ ] `pytest client/tests/test.py` passes locally.

Made with [Cursor](https://cursor.com)