### PR TITLE
fix: return 204 from PATCH /v1/jobs/{id} when the job doc is missing

### DIFF
--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -21,7 +21,8 @@ from time import time
 from typing import Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore import ArrayUnion
 
@@ -109,7 +110,13 @@ async def patch_job_doc(job_id: str, request: Request):
         update["fail_reason"] = ArrayUnion([append])
     if not update:
         return
-    await ASYNC_DB.collection("jobs").document(job_id).update(update)
+    try:
+        await ASYNC_DB.collection("jobs").document(job_id).update(update)
+    except NotFound:
+        # Client's final-except patch_job_sync fires even when /start never
+        # created the doc (e.g. grow failed mid-request). Surfacing 500 here
+        # just generates log noise; the caller already swallows failures.
+        return Response(status_code=204)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Issue
`PATCH /v1/jobs/{job_id}` returns 500 when the target doc does not exist in firestore. The only caller that hits this shape is the client's final-except `patch_job_sync({"status": "FAILED"})` in `_remote_parallel_map.py`, which fires even for jobs whose `/start` never landed the initial job doc. The client swallows the error, but main_service logs a 500.

## Evidence
From GCP Logging (`jack-burla`, 2026-04-21):

```
2026-04-22T01:29:02.024Z ERROR 404 No document to update:
  projects/jack-burla/databases/burla/documents/jobs/download_prerequisite_data-zO7DadTgSjmj
2026-04-22T01:29:02.804Z INFO  PATCH to http://jack.burla.dev/v1/jobs/download_prerequisite_data-zO7DadTgSjmj
  returned 500 after 0.705s
```

The job id `download_prerequisite_data-zO7DadTgSjmj` never shows up in any `POST /v1/jobs/.../start` log, so the client never succeeded in creating it.

## Root cause
[`main_service/src/main_service/endpoints/client.py`](../blob/main/main_service/src/main_service/endpoints/client.py#L98-L112). The endpoint calls `firestore.update()` unconditionally, which raises `google.api_core.exceptions.NotFound` when the doc is absent. `catch_errors` then wraps it as a 500.

## Fix
- Import `NotFound` (already used in `node.py` / `storage.py`) and `Response`.
- Wrap the `update()` call in `try / except NotFound` and return `Response(status_code=204)` for that case. All other paths are unchanged.

Why 204: the client's `patch_job_sync` already swallows any 4xx/5xx; a 204 makes the \"update a non-existent doc\" operation explicitly a no-op instead of an error, which cleans up the ERROR-level log noise and leaves the client contract unchanged.

## Test plan
- [ ] `curl -X PATCH http://localhost:5001/v1/jobs/does-not-exist -H 'Content-Type: application/json' -d '{\"status\": \"FAILED\"}'` returns 204 (was 500).
- [ ] `curl -X PATCH` on an existing job doc still returns 200 and the update lands.
- [ ] `pytest main_service/tests/` passes locally.

Made with [Cursor](https://cursor.com)