### PR TITLE
fix: skip steal iteration when neighbor_id is None

### DIFF
--- a/node_service/src/node_service/job_watcher.py
+++ b/node_service/src/node_service/job_watcher.py
@@ -84,8 +84,12 @@ async def _input_steal_loop(async_db, session, logger, job_started_at, node_ids_
             neighbor_id, neighbor_host, nodes_might_join = await _get_neighbor
             if not (neighbor_id or nodes_might_join):
                 return
-            if not neighbor_id:
-                continue
+
+        # The >60s re-fetch only runs after the grace period, so between job
+        # start and then neighbor_id can still be None from the initial
+        # get_neighbor call. Wait for a real neighbor before building a URL.
+        if not neighbor_id:
+            continue
 
         transfer_id = uuid4().hex
         remaining_inputs = SELF["inputs_queue"].qsize()


### PR DESCRIPTION
## Issue
`_input_steal_loop` could fire an HTTP GET at `None/jobs/.../get_inputs` during the first 60 seconds of a job whenever `get_neighbor` initially returned `(None, None, nodes_might_join=True)`.

## Evidence
From GCP Logging (`jack-burla`, 2026-04-21):

```
2026-04-22T01:33:46.688Z WARNING GET inputs from None failed:
  None/jobs/download_single_idat_file-aMBXnKm1R6eJ/get_inputs
```

Source node: `burla-node-49a1fa9b`. A single occurrence today; the cost is a warning-level log entry and one wasted `aiohttp.ClientSession.get` call per second until a neighbor shows up (or the 60s re-fetch runs).

## Root cause
[`node_service/src/node_service/job_watcher.py`](../blob/main/node_service/src/node_service/job_watcher.py#L66-L107). The existing `if not neighbor_id: continue` guard was nested inside the re-fetch block:

```python
if nodes_might_join and (time() - job_started_at > 60):
    _get_neighbor = get_neighbor(async_db, node_ids_expected)
    neighbor_id, neighbor_host, nodes_might_join = await _get_neighbor
    if not (neighbor_id or nodes_might_join):
        return
    if not neighbor_id:
        continue            # <- only runs when > 60s have passed

transfer_id = uuid4().hex
...
get_url = f"{neighbor_host}/jobs/{SELF['current_job']}/get_inputs"
```

Between job start (after the 10s `should_steal()` gate) and the 60s cutoff, the guard never executed, so a neighbor that was None from the initial `get_neighbor` propagated into the URL.

## Fix
Move the `if not neighbor_id: continue` guard out of the re-fetch conditional so it runs on every iteration. Added a WHY comment explaining the ordering.

## Test plan
- [ ] Unit-level: launch `remote_parallel_map(lambda x: x, inputs, grow=True)` on a cold cluster with `n_inputs=1` so only one node is booted. Before the 60s re-fetch point, no `GET inputs from None failed:` warnings appear.
- [ ] Multi-node job where neighbor shows up at t=30s: the loop stays idle until the neighbor becomes visible, then resumes normal steal behaviour.
- [ ] `pytest node_service/tests/` passes locally.

Made with [Cursor](https://cursor.com)