### PR TITLE
fix: end SSE streams before Cloud Run's 60s cutoff

### DIFF
--- a/main_service/src/main_service/endpoints/cluster_views.py
+++ b/main_service/src/main_service/endpoints/cluster_views.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 from datetime import datetime, timedelta
+from time import time
 from typing import Optional
 
 import pytz
@@ -20,6 +21,11 @@ from main_service.node import Node
 from main_service.endpoints.usage import _to_epoch_ms
 
 router = APIRouter()
+
+# Cloud Run cuts requests at 60s, which on `while True` SSE generators produces
+# a `Truncated response body` warning every cycle. End the stream before that
+# cutoff and rely on the client's EventSource `retry: 5000` to reconnect.
+SSE_MAX_DURATION_SEC = 50
 
 
 def _require_auth(request: Request) -> dict:
@@ -64,10 +70,11 @@ async def cluster_info(request: Request, logger: Logger = Depends(get_logger)):
                 current_loop.call_soon_threadsafe(queue.put_nowait, event_data)
 
         node_watch = DB.collection("nodes").where(filter=active_filter).on_snapshot(on_snapshot)
+        stream_started_at = time()
         try:
             yield "retry: 5000\n\n"
             yield ": init\n\n"
-            while True:
+            while time() - stream_started_at < SSE_MAX_DURATION_SEC:
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=2)
                     yield f"data: {json.dumps(event)}\n\n"
@@ -155,10 +162,11 @@ async def node_log_stream(node_id: str, request: Request):
     watch = logs_ref.on_snapshot(on_snapshot)
 
     async def log_generator():
+        stream_started_at = time()
         try:
             yield "retry: 5000\n\n"
             yield ": init\n\n"
-            while True:
+            while time() - stream_started_at < SSE_MAX_DURATION_SEC:
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=2)
                     yield f"data: {json.dumps(event)}\n\n"

--- a/main_service/src/main_service/endpoints/jobs.py
+++ b/main_service/src/main_service/endpoints/jobs.py
@@ -16,6 +16,11 @@ from main_service import DB, PROJECT_ID
 router = APIRouter()
 ASYNC_DB = firestore.AsyncClient(project=PROJECT_ID, database="burla")
 
+# Cloud Run cuts requests at 60s, which on `while True` SSE generators produces
+# a `Truncated response body` warning every cycle. End the stream before that
+# cutoff and rely on the client's EventSource `retry: 5000` to reconnect.
+SSE_MAX_DURATION_SEC = 50
+
 
 async def current_num_results(job_id: str) -> int:
     job_doc = ASYNC_DB.collection("jobs").document(job_id)
@@ -136,8 +141,9 @@ def job_stream(jobs_current_page: firestore.CollectionReference):
     async def event_stream():
         yield "retry: 5000\n\n"
         yield ": init\n\n"
+        stream_started_at = time()
         try:
-            while True:
+            while time() - stream_started_at < SSE_MAX_DURATION_SEC:
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=10)
                     yield f"data: {json.dumps(event)}\n\n"


### PR DESCRIPTION
## Issue
Every dashboard SSE stream produces a `WARNING Truncated response body` entry in Cloud Run logs once per request cycle. Nothing is broken for the user (EventSource reconnects via `retry: 5000`), but it's a lot of warning-level noise.

## Evidence
From GCP Logging (`jack-burla`, 2026-04-21, single day):

```
904 × WARNING Truncated response body. Usually implies that the request
timed out or the application exited before the response was finished.
```

Cross-referenced with `run.googleapis.com/requests` logs:

```
61.000217073s  200  GET /v1/cluster
61.000341967s  200  GET /v1/jobs?stream=true&page=0
```

Every SSE request lands on a 61.0s latency - Cloud Run's max request time is 60s and the generators never voluntarily end, so Cloud Run cuts them.

## Root cause
Three SSE generators all share the same shape:

- [`cluster_views.py::cluster_info::node_stream`](../blob/main/main_service/src/main_service/endpoints/cluster_views.py)
- [`cluster_views.py::node_log_stream::log_generator`](../blob/main/main_service/src/main_service/endpoints/cluster_views.py)
- [`jobs.py::job_stream::event_stream`](../blob/main/main_service/src/main_service/endpoints/jobs.py)

Each one does:

```python
try:
    yield "retry: 5000\n\n"
    yield ": init\n\n"
    while True:
        try:
            event = await asyncio.wait_for(queue.get(), timeout=N)
            yield f"data: {json.dumps(event)}\n\n"
        except asyncio.TimeoutError:
            yield ": keep-alive\n\n"
finally:
    ...unsubscribe()
```

`while True` never ends, so Cloud Run cuts the transport mid-yield.

## Fix
Add `SSE_MAX_DURATION_SEC = 50` to each file and replace `while True` with `while time() - stream_started_at < SSE_MAX_DURATION_SEC`. The generator exits cleanly, the `finally` block runs (firestore watch unsubscribes), the response closes normally, and the client reconnects after the existing 5s retry delay. Zero user-visible change; Cloud Run logs go quiet.

Why 50s specifically: Cloud Run's limit is 60s, and SSE cycles need to finish their current yield + unsubscribe + response-close inside the remaining window. 10s of headroom is more than enough.

## Test plan
- [ ] Open the dashboard; confirm node / job / log streams keep working as before (indistinguishable UX).
- [ ] In `make local-dev`, confirm each stream endpoint returns 200 after ~50s instead of being cut at 60s.
- [ ] Monitor `run.googleapis.com/varlog/system` after deploy; expect the `Truncated response body` warning count to drop to zero.
- [ ] `pytest main_service/tests/` passes locally.

Made with [Cursor](https://cursor.com)