### PR TITLE
fix(node): skip auto-install for packages already present in the image

### DIFF
--- a/node_service/src/node_service/worker_server.py
+++ b/node_service/src/node_service/worker_server.py
@@ -130,12 +130,13 @@ with socket.create_server(("0.0.0.0", port)) as listener:
                 if command == b"i":
                     packages = pickle.loads(request_payload)
                     missing_packages = []
+                    # Reinstalling to match the client's version would silently replace
+                    # pre-baked GPU wheels (CUDA-built torch, ABI-pinned numpy) with
+                    # incompatible ones from PyPI's default index.
                     for package_name, version in packages.items():
                         try:
-                            installed_version = importlib.metadata.version(package_name)
+                            importlib.metadata.version(package_name)
                         except importlib.metadata.PackageNotFoundError:
-                            installed_version = None
-                        if installed_version != version:
                             missing_packages.append(f"{package_name}=={version}")
                     if missing_packages:
                         subprocess.run(


### PR DESCRIPTION
## Problem

`remote_parallel_map`'s auto-install sniffs the client's packages and ships `(name, version)` pairs to the worker. The worker's install gate in `node_service/worker_server.py` previously reinstalled any package whose client-side version didn't exactly match the worker's installed version. For CPU workflows that was harmless. For images with pre-baked wheels it was destructive:

- Image has `torch==2.4.0` (the CUDA-built wheel shipped by `pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime` — CUDA support is real, just not encoded in the version string).
- Client on Mac has `torch==2.7.0` (whatever the latest CPU wheel is on PyPI's default index).
- `"2.4.0" != "2.7.0"` → worker runs `uv pip install torch==2.7.0` → CUDA build replaced with CPU build → `torch.cuda.is_available()` silently returns False.

Same failure mode for `numpy` pinned by torch for ABI compat, for `sentence-transformers` pinned in a custom Dockerfile, and for anything else the image was built to include at a specific version. Hit this in `scratch/vector_embeddings_demo/`. The current workaround is keeping ML imports inside UDF bodies to hide them from the client-side auto-sniffer (documented as Gotcha #2 in that demo's README), but that becomes a trap once #160 (`feat(auto-install): scan UDF body AST`) lands, since the AST scan will catch those lazy imports.

A narrower PEP 440-base-version fix was considered but only covers images whose METADATA includes a `+cuXXX` local version — not the `pytorch/pytorch` images most users build on top of, and not the version-drift case above.

## Fix

Flip the worker-side policy: if a package is already installed on the worker at _any_ version, skip. The image is the source of truth for preinstalled libs; auto-install is responsible only for filling in what the worker is missing entirely.

`node_service/src/node_service/worker_server.py`:

```python
for package_name, version in packages.items():
    try:
        importlib.metadata.version(package_name)
    except importlib.metadata.PackageNotFoundError:
        missing_packages.append(f"{package_name}=={version}")
```

+4/-3 lines. No helpers, no new imports.

## Behavior change matrix

| Case | Before | After |
| --- | --- | --- |
| Image `torch==2.4.0`, client `torch==2.7.0` | reinstall (stomps CUDA) | **skip** |
| Image `torch==2.4.0+cu121`, client `torch==2.4.0` | reinstall (stomps CUDA) | **skip** |
| Image `numpy==1.26.4` (pinned by torch), client `numpy==2.0.0` | reinstall (breaks torch ABI) | **skip** |
| Client `requests==2.28`, worker `requests==2.25` | reinstall | **skip** |
| Package not on worker | install | install (unchanged) |
| Exact version match | skip | skip (unchanged) |

## Trade-off worth stating

If a UDF depends on API present only in the client's `pandas==2.2` and the worker image happens to have `pandas==1.5`, the UDF now runs against `1.5` and fails at whatever line exercises the 2.2-only behavior. The old policy would have silently upgraded to `2.2` on the worker — which was "better" for that specific case, but was the same mechanism that silently destroyed GPU wheels.

This PR makes the trade-off explicit: images are the source of truth for what's preinstalled, and users are responsible for building images whose pinned versions are compatible with their UDF code. If a user later needs to force the client's version for a specific package, a `force_reinstall=[...]` kwarg is a small client-side follow-up; nothing about this PR blocks that.

## Coordination with #160

This obsoletes the "#171 must land before #160" coordination note. After both land, `import torch` inside a UDF on any GPU image no longer silently replaces the pre-baked wheel — regardless of whether the version strings matched or drifted. #160 can merge on its own schedule.

## Test plan

- [ ] `scratch/vector_embeddings_demo/demo.py` without the lazy-import workaround (i.e. `import torch` at module level) — worker logs no `pip install torch==...`; `torch.cuda.is_available()` still True inside `embed_shard`.
- [ ] Client with a fresh package not present in the image (e.g. `remote_parallel_map(fn, inputs)` where `fn.__globals__` references `polars` and the image doesn't have it) — worker installs it, same as before.
- [ ] Client with an exactly-matching version — no install runs, same as before.
- [ ] Client with a newer minor version of a library the worker has (e.g. client `requests==2.28`, worker `requests==2.25`) — worker now **skips** the reinstall; UDF runs against whatever the worker had.
- [ ] `pytest client/tests/test.py` passes.

---

Made with [Cursor](https://cursor.com)