### PR TITLE
fix(client): surface node's 409 body on refused job assignment

### DIFF
--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -221,6 +221,7 @@ class Node:
         self.result_count = 0
         self.last_reply_timestamp = time()
         self.auth_headers = get_auth_headers()
+        self.removed_reason = ""
         self.spinner_compatible_print = lambda msg: spinner.write(msg) if spinner else print(msg)
 
     def _seconds_since_last_reply(self):
@@ -347,8 +348,11 @@ class Node:
                 elif response.status == 401:
                     raise UnauthorizedError()
                 elif response.status == 409:
+                    reason = (await response.text()).strip()
                     self.state = "REMOVED"
+                    self.removed_reason = reason
                     msg = f"Node {self.instance_name} refused job assignment, removed from job."
+                    msg += f"\n  Reason from node: {reason}"
                     self.spinner_compatible_print(msg)
                     return
                 elif response.status == 503:


### PR DESCRIPTION
## Problem

When a node returns HTTP 409 from `POST /jobs/{id}` the client's `_assign_job` discards the response body and prints only:

```
Node burla-node-xxxxxxxx refused job assignment, removed from job.
```

The body contains the actual reason. From `node_service/__init__.py::CallHookOnJobStartMiddleware` and `node_service/job_endpoints.py::execute_job` (and the three distinct messages [#167](https://github.com/Burla-Cloud/burla/pull/167) is adding):

- `"No compatible containers. User is running python version 3.12, containers in the cluster are running: 3.11."`
- `"Node was assigned 0 parallelism slots..."`
- `"Node has no workers loaded yet (still booting)."`
- `"Node currently running or booting, request refused."`

Each one is actionable. Dropping all of them on the floor and printing a single vague line in every case is bad UX.

### Concrete trace from yesterday

Built a GPU embedding demo (`scratch/vector_embeddings_demo/`) on top of `pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime` (ships Python 3.11.9) with a client on Python 3.12. The cluster cheerfully grew an A100, pulled the 5GB image, and the node responded with a perfectly informative 409:

```
No compatible containers. User is running python version 3.12, containers in the cluster are running: 3.11.
```

The client printed:

```
Node burla-node-50520026 refused job assignment, removed from job.
```

I only found the real reason by reading the node's `lifecycle_endpoints.py` logs via Firestore. Users without repo access would be stuck.

### `_assign_job` as shipped

```349:353:client/src/burla/_node.py
                elif response.status == 409:
                    self.state = "REMOVED"
                    msg = f"Node {self.instance_name} refused job assignment, removed from job."
                    self.spinner_compatible_print(msg)
                    return
```

## Fix

Read the body, include it in the log message, and stash it on `self.removed_reason` so a future JobStalled summary can include it in the per-node report.

```python
elif response.status == 409:
    reason = (await response.text()).strip()
    self.state = "REMOVED"
    self.removed_reason = reason
    msg = f"Node {self.instance_name} refused job assignment, removed from job."
    msg += f"\n  Reason from node: {reason}"
    self.spinner_compatible_print(msg)
    return
```

After this merges, the demo run that took 5 minutes to blame the wrong thing prints:

```
Node burla-node-50520026 refused job assignment, removed from job.
  Reason from node: No compatible containers. User is running python version 3.12, containers in the cluster are running: 3.11.
```

## Coordination

- Independent of [#167](https://github.com/Burla-Cloud/burla/pull/167). #167 fixes what the node *writes* in the body; this PR fixes the fact that the client discards it. The two compose: #167 makes the message accurate, this PR makes the user see it.
- Composes with [#166](https://github.com/Burla-Cloud/burla/pull/166) (`JobStalled`). `self.removed_reason` is populated so that PR's per-node summary can render e.g. `state=REMOVED  reason="..."` once both land. Not a required change here - `removed_reason` is just available for whoever wants it.

## Test plan

- [ ] `remote_parallel_map(lambda x: x, [0], grow=True, image="python:3.11")` from a Python 3.12 client - confirm the printed line includes `Reason from node: No compatible containers...`.
- [ ] Existing 200 / 401 / 503 / other paths unchanged (no new try/except, no behavior change off the 409 branch).
- [ ] `pytest client/tests/test.py` passes.

Made with [Cursor](https://cursor.com)