### PR TITLE
fix: pre-check user python version against image tag in start_job

### DIFF
--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -109,6 +109,7 @@ class ClusterClient:
         from burla._node import (
             NoCompatibleNodes,
             NoNodes,
+            PythonVersionMismatch,
             UnauthorizedError,
             VersionMismatch,
         )
@@ -139,6 +140,8 @@ class ClusterClient:
             )
         if status == 409 and isinstance(detail, dict) and detail.get("error") == "no_compatible_nodes":
             raise NoCompatibleNodes(detail)
+        if status == 409 and isinstance(detail, dict) and detail.get("error") == "python_version_mismatch":
+            raise PythonVersionMismatch(detail)
         if status == 503 and isinstance(detail, dict) and detail.get("error") == "nodes_busy":
             raise NodesBusy()
         if status == 404:

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -104,6 +104,20 @@ class VersionMismatch(Exception):
         super().__init__(msg)
 
 
+class PythonVersionMismatch(Exception):
+    def __init__(self, detail: dict):
+        user = detail["user_python_version"]
+        image = detail["image"]
+        image_py = detail["image_python_version"]
+        msg = f"\n\nYour client is running python {user}, "
+        msg += f"but the image `{image}` ships python {image_py}.\n"
+        msg += "Burla requires an exact major.minor match between client and worker.\n\n"
+        msg += "Either:\n"
+        msg += f"  - run your client on python {image_py}, or\n"
+        msg += f"  - pass `image=python:{user}` (or any other image built on python {user}).\n"
+        super().__init__(msg)
+
+
 class JobCanceled(Exception):
     pass
 

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -41,6 +41,7 @@ from main_service.helpers import (
     Logger,
     gpu_machine_prefix,
     gpu_machine_type,
+    image_python_version,
     parallelism_capacity,
     parse_version,
 )
@@ -307,6 +308,11 @@ async def start_job(
 
     Error responses:
         409 {"detail": {"error": "version_mismatch", ...}}    - client is outside compatible range
+        409 {"detail": {"error": "python_version_mismatch",
+             "user_python_version", "image", "image_python_version"}}
+                                                              - provable mismatch between the client's
+                                                                python and the image's tag; caught here
+                                                                to save the boot + pull wait
         409 {"detail": {"error": "no_compatible_nodes",
              "reason": "image_mismatch"
                      | "gpu_mismatch"
@@ -352,6 +358,23 @@ async def start_job(
         gpu_machine_type(func_gpu)
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error))
+
+    # --- precheck python version against parseable image tags ---
+    # The node will 409 on mismatch anyway, but booting + docker-pulling a heavy
+    # image before hitting that costs minutes. Unparseable images (custom tags)
+    # fall through to the existing boot-and-see path.
+    user_python_version = body["user_python_version"]
+    image_py = image_python_version(image)
+    if image_py and image_py != user_python_version:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "python_version_mismatch",
+                "user_python_version": user_python_version,
+                "image": image,
+                "image_python_version": image_py,
+            },
+        )
 
     # --- select from cached ready nodes ---
     (

--- a/main_service/src/main_service/helpers.py
+++ b/main_service/src/main_service/helpers.py
@@ -103,6 +103,22 @@ def parse_version(version_str: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version_str.split("."))
 
 
+def image_python_version(image: Optional[str]) -> Optional[str]:
+    """Return the 'MAJOR.MINOR' Python version of a `python:...` image tag.
+
+    Returns None for any image we cannot confidently parse (custom images,
+    slim variants without a Python version, etc.). The caller should treat
+    None as 'unknown, don't pre-check'.
+    """
+    if not image or not image.startswith("python:"):
+        return None
+    tag = image.removeprefix("python:").split("-", 1)[0]
+    parts = tag.split(".")
+    if len(parts) < 2 or not all(part.isdigit() for part in parts[:2]):
+        return None
+    return f"{parts[0]}.{parts[1]}"
+
+
 def format_traceback(traceback_details: list):
     details = ["  ... (detail hidden)\n" if "/pypoetry/" in d else d for d in traceback_details]
     details = [key for key, _ in groupby(details)]  # <- remove consecutive duplicates


### PR DESCRIPTION
## Problem

When `remote_parallel_map` is called with an `image=` whose tag names a Python version that the client's Python cannot match, the cluster does the full expensive dance - provision a VM, docker-pull a multi-GB image, boot the node-service - and *then* the node returns HTTP 409 on `POST /jobs/{id}`:

```
No compatible containers. User is running python version 3.12,
containers in the cluster are running: 3.11.
```

On a cold GPU cluster this burns 5-10 minutes per submission. Hit it yesterday standing up a CUDA embedding demo: `pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime` ships Python 3.11.9, my client was 3.12 (default), and every first run on a cold cluster wasted several minutes pulling the image to learn something the server already had enough info to catch. Same failure mode every time a user pastes `image="python:3.11"` into a script running on `python:3.12`.

The server already has both pieces:
- `body["user_python_version"]` - sent on every `POST /v1/jobs/{id}/start`.
- `body["image"]` - the effective image the grown nodes will boot (the client defaults `image=f"python:3.{minor}"` for `grow=True, image=None`, so the server sees a concrete tag in every provable case).

Nothing parsed the tag and compared.

## Fix

Three small pieces:

- `main_service/helpers.py::image_python_version(image)` - parses `python:X.Y[.Z][-...]` into `"X.Y"`. Returns `None` for anything it can't confidently parse (custom images, `python:latest`, `python:3`, `nvcr.io/...`, etc.). The caller treats `None` as "unknown, don't pre-check".
- `main_service/endpoints/client.py::start_job` - right after `gpu_machine_type(func_gpu)` validation, compare `image_python_version(image)` against `user_python_version`. Mismatch -> `409 {"error": "python_version_mismatch", "user_python_version", "image", "image_python_version"}`. The boot/grow path is untouched.
- Client: new `PythonVersionMismatch(Exception)` in `client/_node.py` with an actionable user-facing message, plumbed through the 409 branch in `_cluster_client.ClusterClient.start_job`.

Example message the user sees now:

```
PythonVersionMismatch:

Your client is running python 3.12, but the image `python:3.11` ships python 3.11.
Burla requires an exact major.minor match between client and worker.

Either:
  - run your client on python 3.11, or
  - pass `image=python:3.12` (or any other image built on python 3.12).
```

### Parser sanity check

Covered by inline test during development (all pass):

| Input | Result |
| --- | --- |
| `python:3.11` | `3.11` |
| `python:3.11.9` | `3.11` |
| `python:3.11-slim` | `3.11` |
| `python:3.11.9-slim-bookworm` | `3.11` |
| `python:3.12-alpine` | `3.12` |
| `python:3` | `None` (refuse to guess) |
| `python:latest` | `None` |
| `python:` | `None` |
| `pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime` | `None` |
| `nvcr.io/nvidia/pytorch:24.08-py3` | `None` |
| `None` / `""` | `None` |

## What this does not do

Custom images (most real GPU workflows) are unparseable from the tag alone. Those keep hitting the old boot-and-see path. A follow-up could write `workers_python_versions` into the node's Firestore doc on boot and use `NODES_CACHE` to pre-check against already-READY custom images - intentionally left out of this PR to keep the diff small and review-local to `start_job`.

## Test plan

- [ ] `remote_parallel_map(lambda x: x, [0], grow=True, image="python:3.11")` from a Python 3.12 client - fails at submission with `PythonVersionMismatch`; no VM boot, no image pull.
- [ ] `remote_parallel_map(lambda x: x, [0], grow=True)` from a Python 3.12 client (client defaults `image=python:3.12`) - matches, submits normally.
- [ ] `remote_parallel_map(lambda x: x, [0], grow=True, image="jakezuliani/burla-embedder:latest")` - unparseable tag, falls through to the old path unchanged.
- [ ] `pytest client/tests/test.py` passes.

Made with [Cursor](https://cursor.com)