### PR TITLE
fix: surface actionable reasons at every node-failure surface

### DIFF
--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -192,6 +192,19 @@ class ClusterClient:
     async def get_node(self, node_id: str) -> Optional[dict]:
         return await self._request("GET", f"/v1/cluster/nodes/{node_id}")
 
+    async def get_node_fail_reason(self, node_id: str) -> Optional[str]:
+        # Swallow all errors — a failed enrichment lookup must never escalate
+        # into a worse error than the NodeDisconnected the caller is already
+        # about to raise.
+        try:
+            result = await self._request("GET", f"/v1/cluster/nodes/{node_id}/fail_reason")
+        except Exception:
+            return None
+        if not result:
+            return None
+        reason = (result.get("reason") or "").strip()
+        return reason or None
+
     async def fail_node(self, node_id: str, reason: str) -> None:
         await self._request(
             "POST",

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -109,6 +109,10 @@ class JobCanceled(Exception):
     pass
 
 
+class JobStalled(Exception):
+    pass
+
+
 class ClusterRestarted(Exception):
     def __init__(self):
         message = "\n\nThe cluster was restarted. "
@@ -223,6 +227,7 @@ class Node:
         self.last_reply_timestamp = time()
         self.started_booting_at = time()
         self.auth_headers = get_auth_headers()
+        self.removed_reason = ""
         self.spinner_compatible_print = lambda msg: spinner.write(msg) if spinner else print(msg)
 
     def _seconds_since_last_reply(self):
@@ -233,6 +238,24 @@ class Node:
 
     def _node_silence_timeout_message(self, action: str):
         return f"Node {self.instance_name} has not replied for over 2 minutes while {action}.\n"
+
+    async def _failure_message(self, base_msg: str | None = None) -> str:
+        base = base_msg or f"Node {self.instance_name} failed during job."
+        reason = await self.client.get_node_fail_reason(self.instance_name)
+        # Fall back to base so enrichment can never produce a worse error than before.
+        if not reason:
+            return base
+        return f"{base}\n\nLast error reported by the node:\n{reason}"
+
+    async def _stall_summary_line(self) -> str:
+        line = f"  {self.instance_name}  state={self.state}  result_count={self.result_count}"
+        if self.state == "FAILED":
+            reason = await self.client.get_node_fail_reason(self.instance_name)
+            if reason:
+                line += f"\n    reason: {reason}"
+        elif self.state == "REMOVED" and self.removed_reason:
+            line += f"\n    reason: {self.removed_reason}"
+        return line
 
     def _empty_node_results(self):
         return {
@@ -353,8 +376,12 @@ class Node:
                 elif response.status == 401:
                     raise UnauthorizedError()
                 elif response.status == 409:
+                    reason = (await response.text()).strip()
                     self.state = "REMOVED"
+                    self.removed_reason = reason
                     msg = f"Node {self.instance_name} refused job assignment, removed from job."
+                    if reason:
+                        msg += f"\n  Reason from node: {reason}"
                     self.spinner_compatible_print(msg)
                     return
                 elif response.status == 503:
@@ -407,11 +434,11 @@ class Node:
                     if job_doc and job_doc.get("status") == "CANCELED":
                         raise JobCanceled("Job canceled from dashboard.")
                     msg = f"Node {self.instance_name} disconnected while transmitting results.\n"
-                    raise NodeDisconnected(self, msg)
+                    raise NodeDisconnected(self, await self._failure_message(msg))
         except NETWORK_ERROR_TYPES:
             if self._node_silence_timeout_exceeded():
                 msg = self._node_silence_timeout_message("returning results")
-                raise NodeDisconnected(self, msg)
+                raise NodeDisconnected(self, await self._failure_message(msg))
             return self._empty_node_results()
 
         if node_results.get("cluster_shutdown"):
@@ -532,7 +559,7 @@ class Node:
                         msg = f"Worker on node {self.instance_name} failed "
                         msg += "(the cluster may have been restarted):\n\n"
                         msg += error_info["traceback_str"]
-                        raise NodeDisconnected(self, msg)
+                        raise NodeDisconnected(self, await self._failure_message(msg))
                     traceback = Traceback.from_dict(error_info["traceback_dict"]).as_traceback()
                     self.udf_error_event.set()
                     log_error = RemoteParallelMapReporter.log_user_function_error_async

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -32,6 +32,7 @@ from burla._node import (
     ClusterRestarted,
     ClusterShutdown,
     JobCanceled,
+    JobStalled,
     MainServiceTimeout,
     Node,
     NoCompatibleNodes,
@@ -70,6 +71,7 @@ EXEC_TYPES_TO_NOT_ALERT = [
     AllNodesBusy,
     NoCompatibleNodes,
     JobCanceled,
+    JobStalled,
     ClusterRestarted,
     ClusterShutdown,
     VersionMismatch,
@@ -245,7 +247,8 @@ async def _execute_job(
 
             for task, node in zip(node_tasks, nodes):
                 exception = task.exception() if task.done() else None
-                exception = NodeDisconnected(node) if node.state == "FAILED" else exception
+                if node.state == "FAILED":
+                    exception = NodeDisconnected(node, await node._failure_message())
                 if exception:
                     # Authoritative check via main_service: if main_service has
                     # already written a lifecycle signal on the job doc, raise
@@ -295,7 +298,13 @@ async def _execute_job(
 
             total_result_count = sum(node.result_count for node in nodes)
             if all([task.done() for task in node_tasks]) and total_result_count < n_inputs:
-                raise Exception("Zero nodes working on job and we have not received all results!")
+                summary = "\n".join([await n._stall_summary_line() for n in nodes])
+                msg = (
+                    f"Job ended before all results were received "
+                    f"({total_result_count}/{n_inputs}).\n"
+                    f"Final node states:\n{summary}\n"
+                )
+                raise JobStalled(msg)
 
         job_success_telemetry_task = create_task(
             reporter.log_job_success_telemetry(time() - start_time)

--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -524,6 +524,23 @@ async def get_cluster_node(node_id: str):
     return data
 
 
+# Earliest log matching one of these is usually the root cause; later logs
+# ("Startup script failed!", timeout tracebacks) are cascades.
+_FAIL_LOG_TOKENS = ("Error", "error", "failed", "Traceback", "Exception")
+
+
+# 404 on "no match" lets the client distinguish real failure explanations
+# from innocuous info logs and fall back cleanly.
+@router.get("/v1/cluster/nodes/{node_id}/fail_reason")
+async def get_node_fail_reason(node_id: str):
+    logs_ref = ASYNC_DB.collection("nodes").document(node_id).collection("logs")
+    async for doc in logs_ref.order_by("ts").stream():
+        msg = ((doc.to_dict() or {}).get("msg") or "").strip()
+        if msg and any(tok in msg for tok in _FAIL_LOG_TOKENS):
+            return {"reason": msg}
+    raise HTTPException(status_code=404, detail="no failure log for node")
+
+
 @router.post("/v1/cluster/nodes/{node_id}/fail")
 async def fail_cluster_node(
     node_id: str,


### PR DESCRIPTION
Three independent error-surface PRs (#163, #166, #172) rolled into one coherent change. Together they turn the three opaque failure messages users see today into actionable diagnoses.

## Problem

When jobs fail, users currently see one of three uninformative errors:

1. **`NodeDisconnected`** — `Node burla-node-xxx failed during job.` — the real reason is in the node's Firestore log subcollection, but users need dashboard / Firestore access to read it.
2. **`Exception("Zero nodes working on job and we have not received all results!")`** — bare `Exception` from `_execute_job`'s final sanity check. Says nothing about *which* nodes died or *why*.
3. **Refused assignment (HTTP 409)** — client discards the response body and prints only `Node ... refused job assignment, removed from job.` The 409 body (now informative thanks to #167) gets thrown away.

Each was its own PR. They compose naturally — each of (2) and (3) becomes more useful once (1) lands, and the `JobStalled` summary in (2) wants the per-node reason enrichment from (1) and the `removed_reason` from (3).

## Fix

### 1. New endpoint: `GET /v1/cluster/nodes/{node_id}/fail_reason` (`main_service/endpoints/client.py`)

Scans the node's `logs` subcollection and returns the earliest message containing any of `Error / error / failed / Traceback / Exception`. Returns `404` when nothing matches, so the client can cleanly tell "no diagnosis available" from a real one. Earliest, not latest, because later logs are almost always cascades of the first real failure (`Startup script failed!`, timeout tracebacks, etc.).

### 2. Client helper: `ClusterClient.get_node_fail_reason` + `Node._failure_message(base_msg)`

`get_node_fail_reason` fetches the reason as a plain string and swallows network/HTTP errors — a failed enrichment lookup must never escalate into a worse error than the `NodeDisconnected` the caller was already about to raise.

`Node._failure_message(base)` appends the reason under `Last error reported by the node:` and falls back to `base` unchanged if the lookup returns nothing. All four `NodeDisconnected` raise sites (3 in `_node.py`, 1 in `_remote_parallel_map.py`) now route through it — so users never get a `NodeDisconnected` with less information than before, and almost always more.

### 3. `JobStalled(Exception)` replaces the opaque fallback

New `JobStalled` in `_node.py` (matches file convention: no docstring, just `pass`, like `JobCanceled` and `NoNodes`). Its message lists each node's terminal state + `result_count` + — thanks to (2) and (4) — the per-node reason when available:

```
Job ended before all results were received (0/10).
Final node states:
  burla-node-a1b2c3d4  state=FAILED   result_count=0
    reason: docker pull: 403 pull access denied for jakezuliani/...
  burla-node-e5f6g7h8  state=REMOVED  result_count=0
    reason: No compatible containers. Client is python 3.12, ...
```

Added to `EXEC_TYPES_TO_NOT_ALERT` so clean node-level diagnoses don't page Sentry.

### 4. 409 refused-assignment body surfaced (`Node._assign_job`)

The 409 branch now reads the response body, stashes it on `self.removed_reason`, and includes it in the printed line. Composes with already-merged #167 — #167 made those messages accurate, this makes users see them.

## What this supersedes

| Original PR | Status |
| --- | --- |
| #163 — Include the node's last error in NodeDisconnected | superseded by parts (1) + (2) of this PR |
| #166 — Informative JobStalled error | superseded by part (3), plus reason enrichment from (1) |
| #172 — Surface node's 409 body | superseded by part (4) |

Each of those PRs will be closed pointing here once this is up.

## Test plan

- [ ] `remote_parallel_map(fn, [0], grow=True, image="bad-image:v1")` — `NodeDisconnected` message includes the docker-pull error from the node logs.
- [ ] Kill a worker container mid-job — `NodeDisconnected` surfaces the worker traceback via `_failure_message`.
- [ ] `remote_parallel_map(lambda x: x, [0], grow=True, image="python:3.11")` from a Python-3.12 client — `JobStalled` raised; summary names the REMOVED node with the 409 reason inline (now that #167 is merged, that reason is the informative "No compatible containers..." string).
- [ ] Happy-path job — unchanged.
- [ ] `pytest client/tests/test.py` passes.

Closes #163
Closes #166
Closes #172

---

Made with [Cursor](https://cursor.com)