### PR TITLE
cleanup: batch log-noise and cosmetic fixes

### DIFF
--- a/main_service/src/main_service/endpoints/client.py
+++ b/main_service/src/main_service/endpoints/client.py
@@ -21,7 +21,8 @@ from time import time
 from typing import Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore import ArrayUnion
 
@@ -109,7 +110,11 @@ async def patch_job_doc(job_id: str, request: Request):
         update["fail_reason"] = ArrayUnion([append])
     if not update:
         return
-    await ASYNC_DB.collection("jobs").document(job_id).update(update)
+    try:
+        await ASYNC_DB.collection("jobs").document(job_id).update(update)
+    except NotFound:
+        # Caller swallows the failure; 500 here is just log noise.
+        return Response(status_code=204)
 
 
 # ------------------------------------------------------------------

--- a/main_service/src/main_service/endpoints/cluster_views.py
+++ b/main_service/src/main_service/endpoints/cluster_views.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 from datetime import datetime, timedelta
+from time import time
 from typing import Optional
 
 import pytz
@@ -20,6 +21,9 @@ from main_service.node import Node
 from main_service.endpoints.usage import _to_epoch_ms
 
 router = APIRouter()
+
+# Cloud Run cuts at 60s and logs "Truncated response body" each cycle; client's EventSource reconnects.
+SSE_MAX_DURATION_SEC = 50
 
 
 def _require_auth(request: Request) -> dict:
@@ -64,10 +68,11 @@ async def cluster_info(request: Request, logger: Logger = Depends(get_logger)):
                 current_loop.call_soon_threadsafe(queue.put_nowait, event_data)
 
         node_watch = DB.collection("nodes").where(filter=active_filter).on_snapshot(on_snapshot)
+        stream_started_at = time()
         try:
             yield "retry: 5000\n\n"
             yield ": init\n\n"
-            while True:
+            while time() - stream_started_at < SSE_MAX_DURATION_SEC:
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=2)
                     yield f"data: {json.dumps(event)}\n\n"
@@ -155,10 +160,11 @@ async def node_log_stream(node_id: str, request: Request):
     watch = logs_ref.on_snapshot(on_snapshot)
 
     async def log_generator():
+        stream_started_at = time()
         try:
             yield "retry: 5000\n\n"
             yield ": init\n\n"
-            while True:
+            while time() - stream_started_at < SSE_MAX_DURATION_SEC:
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=2)
                     yield f"data: {json.dumps(event)}\n\n"

--- a/main_service/src/main_service/endpoints/jobs.py
+++ b/main_service/src/main_service/endpoints/jobs.py
@@ -16,6 +16,9 @@ from main_service import DB, PROJECT_ID
 router = APIRouter()
 ASYNC_DB = firestore.AsyncClient(project=PROJECT_ID, database="burla")
 
+# Cloud Run cuts at 60s and logs "Truncated response body" each cycle; client's EventSource reconnects.
+SSE_MAX_DURATION_SEC = 50
+
 
 async def current_num_results(job_id: str) -> int:
     job_doc = ASYNC_DB.collection("jobs").document(job_id)
@@ -136,8 +139,9 @@ def job_stream(jobs_current_page: firestore.CollectionReference):
     async def event_stream():
         yield "retry: 5000\n\n"
         yield ": init\n\n"
+        stream_started_at = time()
         try:
-            while True:
+            while time() - stream_started_at < SSE_MAX_DURATION_SEC:
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=10)
                     yield f"data: {json.dumps(event)}\n\n"

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -185,6 +185,7 @@ class Node:
             "machine_types_client",
             "node_ref",
             "auth_headers",
+            "is_booting",
         ]
         current_state = {k: v for k, v in current_state.items() if k not in attrs_to_not_save}
         self.node_ref.set(current_state)

--- a/node_service/src/node_service/job_watcher.py
+++ b/node_service/src/node_service/job_watcher.py
@@ -84,8 +84,9 @@ async def _input_steal_loop(async_db, session, logger, job_started_at, node_ids_
             neighbor_id, neighbor_host, nodes_might_join = await _get_neighbor
             if not (neighbor_id or nodes_might_join):
                 return
-            if not neighbor_id:
-                continue
+
+        if not neighbor_id:
+            continue
 
         transfer_id = uuid4().hex
         remaining_inputs = SELF["inputs_queue"].qsize()


### PR DESCRIPTION
## Why

Four small, independent cleanups rolled into one diff. Each fixes a different kind of noise or misleading state that's accumulated as the codebase grew; each is individually too small to justify its own review cycle.

## What changes

### 1. `main_service/endpoints/{cluster_views,jobs}.py` — bound SSE streams to 50s

**What's broken.** Cloud Run kills any HTTP request at 60s, which on a `while True` SSE generator produces a `Truncated response body` warning every cycle — ~904/day on `jack-burla`. The frontend already rotates each SSE EventSource at 55s (`ROTATE_MS` in `NodesContext`, `JobsContext`, `NodesList`) specifically to dodge this, but non-dashboard consumers (CLI tools, direct-API scripts, tests) and occasional race conditions still trigger it.

**Why it's useful.** The truncation warnings are by far the loudest repeated message in Cloud Run logs. When skimming logs for real errors you have to mentally filter them every time — which costs time and risks hiding a real 500 in the noise.

**User-visible effect.** None on the dashboard — the rotation behavior is unchanged; users never saw the 55s reopen and won't see a 50s server-side close either. Direct-API SSE clients get a clean stream end instead of a truncated mid-response.

### 2. `main_service/endpoints/client.py` — 204 on `PATCH /v1/jobs/{id}` when doc is missing

**What's broken.** The client's final-except fires `patch_job_sync({"status": "FAILED"})` on any unhandled exit — including cases where `/start` never landed the initial job doc (e.g. grow failed before the firestore write). `firestore.update` then raises `NotFound`, which `catch_errors` wraps as a 500. `patch_job_sync` is explicitly documented to "swallow any failure", so the client has already moved on.

**Why it's useful.** A 500 in logs should mean something is wrong. Every grow-failure currently emits this bogus 500 for what is, semantically, an idempotent no-op cleanup. Returning 204 makes "any 500 on `/v1/jobs/*`" a real signal again.

**User-visible effect.** None. The client swallows the response regardless; only the status code changes.

### 3. `node_service/job_watcher.py` — `None`-neighbor guard runs every iteration

**What's broken.** `_input_steal_loop` had `if not neighbor_id: continue` nested inside the `if nodes_might_join and (time() - job_started_at > 60)` re-fetch block, so the guard only took effect after the first 60s of a job. During those first 60s, if the initial `get_neighbor` call returned a `None` `neighbor_id` (other nodes still booting but `nodes_might_join` true), the loop fell through and built a literal `"None/jobs/<id>/get_inputs"` URL. `aiohttp` fails it and `job_watcher.py` logs `GET inputs from {neighbor_id} failed: {error}` — up to once per second for nearly a minute on every cold-start multi-node job.

**Why it's useful.** This is a real bug, not hygiene. The affected window (first 60s) is exactly when a user debugging a slow start is most likely to be tailing node logs.

**User-visible effect.** On cold-start multi-node jobs, users tailing `burla logs <node>` stop seeing the `GET inputs from None failed` spam. Job behavior is unchanged — the failures were already caught, and nothing was actually being stolen in that window anyway (the neighbor wasn't ready yet).

### 4. `main_service/node.py` — don't persist `is_booting` to Firestore

**What's broken.** `Node.start()` dumps `self.__dict__` to Firestore via `node_ref.set(...)`, which writes `is_booting=True` onto the node doc at boot time. Nothing clears it: `from_firestore_snapshot` reconstructs the attribute from `status == "BOOTING"` and ignores the stored value, and no other code reads it back. Every node doc ends up with a permanently-stale `is_booting=True` field that survives through ready → running → shutdown.

**Why it's useful.** Anyone poking at node docs directly (GCP console, ad-hoc scripts, a future feature that needs `is_booting`) would see the stale value and either make wrong decisions or waste time figuring out the discrepancy. Stopping the write now is cheaper than cleaning it up later.

**User-visible effect.** None on the dashboard (it reads `status`, not `is_booting`). Affects the next engineer who opens the Firestore console.

## What this supersedes

| PR | |
| --- | --- |
| #170 | end SSE streams before 60s |
| #168 | 204 on PATCH /v1/jobs/{id} missing doc |
| #169 | skip steal iteration when neighbor_id is None |
| #158 | don't leak is_booting to firestore |

## Test plan

- [ ] Dashboard SSE streams keep delivering events normally; each endpoint returns 200 after ~50s instead of being truncated at 60s.
- [ ] Cloud Run `Truncated response body` count drops to zero post-deploy.
- [ ] `PATCH /v1/jobs/does-not-exist` returns 204 (was 500).
- [ ] Fresh cluster — `nodes/{id}` Firestore docs do not contain `is_booting`.
- [ ] Cold-start multi-node job — no `GET inputs from None failed` warnings in node logs during the first 60s.

Closes #170
Closes #168
Closes #169
Closes #158

---

Made with [Cursor](https://cursor.com)