### PR TITLE
feat(dev): isolate Burla agent work with task worktrees

### DIFF
--- a/.cursor/rules/burla-ephemeral-dev-vm.mdc
+++ b/.cursor/rules/burla-ephemeral-dev-vm.mdc
@@ -1,0 +1,8 @@
+---
+description: Burla agent tasks must use linked worktrees before using dev VMs
+alwaysApply: true
+---
+
+# Burla Ephemeral Dev VM
+
+For Burla agent tasks, never edit the primary checkout directly. First create or reopen a linked task worktree, move into it, and only then use the `scripts/dev_vm_*.sh` workflow. Prefer the Burla dev-VM skill and the `scripts/dev-worktree/*.sh` helpers over ad hoc `git worktree`, `gcloud`, `ssh`, or `scp` commands.

--- a/.cursor/skills/burla-ephemeral-dev-vm/SKILL.md
+++ b/.cursor/skills/burla-ephemeral-dev-vm/SKILL.md
@@ -5,29 +5,38 @@ description: Provision and use isolated ephemeral GCP VMs for Burla local-dev. U
 
 # Burla Ephemeral Dev VM
 
-Use the `scripts/dev_vm_*.sh` commands instead of handwritten `gcloud`, `ssh`, or `scp` sequences.
+Use the worktree and VM scripts instead of handwritten `git worktree`, `gcloud`, `ssh`, or `scp` sequences.
 
 ## Defaults
 
-- One active agent task gets one fresh VM.
+- One active agent task gets one fresh linked worktree, one fresh task branch, and one fresh VM.
+- Always edit from the linked worktree, never from the primary checkout.
 - Reuse the dedicated project slot for that agent ID unless the user asks otherwise.
 - Default to `make local-dev` on the VM.
 - Use the script-reported `http://localhost:<port>` URL for browser and client work.
 - Destroy the VM when the task is complete unless the user asked to keep it.
+- Keep the worktree and branch until explicit cleanup so work-in-progress is not lost.
 
 ## Standard Workflow
 
-1. `scripts/dev_vm_create.sh --agent <id>`
-2. `scripts/dev_vm_wait_ssh.sh --agent <id>`
-3. `scripts/dev_vm_sync_repo.sh --agent <id>`
-4. `scripts/dev_vm_start_local_dev.sh --agent <id>`
-5. `scripts/dev_vm_tunnel.sh --agent <id>`
-6. `scripts/dev_vm_status.sh --agent <id>`
-7. For local client work, run `scripts/dev_vm_client_shell.sh --agent <id> --python <version>`
-8. When done, run `scripts/dev_vm_destroy.sh --agent <id>`
+1. From the primary checkout, run `scripts/dev-worktree/create.sh --agent <id> --task <task-slug>`.
+2. `cd` into the printed worktree path.
+3. Make code changes only from that linked worktree.
+4. Run `scripts/dev_vm_create.sh --agent <id>`.
+5. Run `scripts/dev_vm_wait_ssh.sh --agent <id>`.
+6. Run `scripts/dev_vm_sync_repo.sh --agent <id>`.
+7. Run `scripts/dev_vm_start_local_dev.sh --agent <id>`.
+8. Run `scripts/dev_vm_tunnel.sh --agent <id>`.
+9. Run `scripts/dev_vm_status.sh --agent <id>`.
+10. For local client work, run `scripts/dev_vm_client_shell.sh --agent <id> --python <version>`.
+11. When done, run `scripts/dev_vm_destroy.sh --agent <id>`.
+12. Remove the worktree later with `scripts/dev-worktree/remove.sh --agent <id> --task <task-slug>` only when you are done with that branch.
 
 ## Guardrails
 
+- Never edit the primary checkout for an agent task.
+- Never run the `scripts/dev_vm_*.sh` commands from the primary checkout.
+- The current branch must match `agent/<id>/<task-slug>` before VM scripts run.
 - Never share a VM across active agents.
 - Never expose port `5001` publicly.
 - Never assume the dashboard URL is `http://localhost:5001`; always read the state file or status output.

--- a/.cursor/skills/burla-ephemeral-dev-vm/reference.md
+++ b/.cursor/skills/burla-ephemeral-dev-vm/reference.md
@@ -1,5 +1,17 @@
 # Burla Ephemeral Dev VM Reference
 
+## Worktree Contract
+
+- Task branch: `agent/<id>/<task-slug>`
+- Worktree path: `../burla-worktrees/agent-<id>/<task-slug>`
+- Create and remove worktrees from the primary checkout
+- Run all `scripts/dev_vm_*.sh` commands from inside the linked worktree
+
+Examples:
+
+- Agent `01`, task `fix-auth-flow` -> branch `agent/01/fix-auth-flow` -> worktree `../burla-worktrees/agent-01/fix-auth-flow`
+- Agent `02`, task `improve-jobs-ui` -> branch `agent/02/improve-jobs-ui` -> worktree `../burla-worktrees/agent-02/improve-jobs-ui`
+
 ## Naming Contract
 
 - Project slot: `burla-agent-<id>`
@@ -18,6 +30,9 @@ State and keys are split deliberately: the repo's `.cursor/` folder is a common 
 
 ## Script Roles
 
+- `scripts/dev-worktree/create.sh`: create or reopen a linked worktree and branch for the current task
+- `scripts/dev-worktree/status.sh`: report whether the expected task worktree exists and which branch it is on
+- `scripts/dev-worktree/remove.sh`: remove the linked worktree and optionally delete the branch
 - `scripts/dev_vm_create.sh`: create or reuse the project slot, create a fresh VM, and write the local state file
 - `scripts/dev_vm_wait_ssh.sh`: wait until SSH works and the startup bootstrap is complete
 - `scripts/dev_vm_sync_repo.sh`: copy the current local repo state to `/srv/burla` on the VM
@@ -30,6 +45,8 @@ State and keys are split deliberately: the repo's `.cursor/` folder is a common 
 ## Local Client Caveat
 
 The repo’s stock `make 3.11-dev` / `make 3.12-dev` helpers hardcode `http://localhost:5001`. For ephemeral remote VMs, use `scripts/dev_vm_client_shell.sh` instead so each agent task gets its own tunneled dashboard URL.
+
+The VM scripts also assume they are running from a linked task worktree. They should fail if they are run from the primary checkout or from a branch that does not match `agent/<id>/<task-slug>`.
 
 ## Config Knobs
 
@@ -47,13 +64,18 @@ These scripts accept optional environment overrides when the defaults are wrong 
 - `BURLA_DEV_VM_REMOTE_REPO_DIR`
 - `BURLA_DEV_VM_REMOTE_LOG_PATH`
 - `BURLA_DEV_VM_KEY_DIR` (default `~/.ssh/burla-dev-vm`)
+- `BURLA_DEV_WORKTREE_BASE_DIR` (default sibling dir `../burla-worktrees`)
+- `BURLA_DEV_WORKTREE_BASE_REF` (default `main`)
 
 ## Expected Loop
 
-1. Create the VM.
-2. Wait for bootstrap.
-3. Sync the repo.
-4. Start local-dev.
-5. Start the tunnel.
-6. Use the dashboard and local client shell.
-7. Destroy the VM when done.
+1. From the primary checkout, create or reopen the task worktree.
+2. `cd` into the worktree and do all edits there.
+3. Create the VM.
+4. Wait for bootstrap.
+5. Sync the worktree snapshot.
+6. Start local-dev.
+7. Start the tunnel.
+8. Use the dashboard and local client shell.
+9. Destroy the VM when done.
+10. Remove the worktree later only when the task branch is no longer needed.

--- a/scripts/dev-worktree/create.sh
+++ b/scripts/dev-worktree/create.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THIS_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/dev_vm_common.sh
+source "$THIS_SCRIPT_DIR/../dev_vm_common.sh"
+
+parse_agent_task_and_base "$@"
+require_command git
+require_primary_checkout_context
+
+BRANCH_NAME="$(branch_name_for_task "$AGENT_ID" "$TASK_SLUG")"
+WORKTREE_PATH="$(worktree_path_for_task "$AGENT_ID" "$TASK_SLUG")"
+WORKTREE_EXISTS="false"
+BRANCH_EXISTS="false"
+CREATED_WORKTREE="false"
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  BRANCH_EXISTS="true"
+fi
+
+if [[ -d "$WORKTREE_PATH" ]]; then
+  EXISTING_TOPLEVEL="$(git -C "$WORKTREE_PATH" rev-parse --show-toplevel 2>/dev/null)" || fail "Path [$WORKTREE_PATH] exists but is not a git worktree."
+  EXISTING_BRANCH="$(git -C "$WORKTREE_PATH" branch --show-current)"
+  [[ "$EXISTING_TOPLEVEL" == "$WORKTREE_PATH" ]] || fail "Worktree path [$WORKTREE_PATH] resolves to [$EXISTING_TOPLEVEL]."
+  [[ "$EXISTING_BRANCH" == "$BRANCH_NAME" ]] || fail "Worktree [$WORKTREE_PATH] is on branch [$EXISTING_BRANCH], expected [$BRANCH_NAME]."
+  WORKTREE_EXISTS="true"
+else
+  mkdir -p "$(dirname "$WORKTREE_PATH")"
+  if [[ "$BRANCH_EXISTS" == "true" ]]; then
+    git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" >/dev/null
+  else
+    git rev-parse --verify "$BASE_REF" >/dev/null 2>&1 || fail "Base ref [$BASE_REF] was not found."
+    git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$BASE_REF" >/dev/null
+    BRANCH_EXISTS="true"
+  fi
+  WORKTREE_EXISTS="true"
+  CREATED_WORKTREE="true"
+fi
+
+AGENT_ID="$AGENT_ID" \
+TASK_SLUG="$TASK_SLUG" \
+BASE_REF="$BASE_REF" \
+BRANCH_NAME="$BRANCH_NAME" \
+WORKTREE_PATH="$WORKTREE_PATH" \
+PRIMARY_CHECKOUT_PATH="$PRIMARY_CHECKOUT_PATH" \
+WORKTREE_EXISTS="$WORKTREE_EXISTS" \
+BRANCH_EXISTS="$BRANCH_EXISTS" \
+CREATED_WORKTREE="$CREATED_WORKTREE" \
+python3 - <<'PY'
+import json
+import os
+
+print(
+    json.dumps(
+        {
+            "agent_id": os.environ["AGENT_ID"],
+            "task_slug": os.environ["TASK_SLUG"],
+            "base_ref": os.environ["BASE_REF"],
+            "branch_name": os.environ["BRANCH_NAME"],
+            "worktree_path": os.environ["WORKTREE_PATH"],
+            "primary_checkout_path": os.environ["PRIMARY_CHECKOUT_PATH"],
+            "branch_exists": os.environ["BRANCH_EXISTS"] == "true",
+            "worktree_exists": os.environ["WORKTREE_EXISTS"] == "true",
+            "created_worktree": os.environ["CREATED_WORKTREE"] == "true",
+        },
+        indent=2,
+    )
+)
+PY

--- a/scripts/dev-worktree/remove.sh
+++ b/scripts/dev-worktree/remove.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THIS_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/dev_vm_common.sh
+source "$THIS_SCRIPT_DIR/../dev_vm_common.sh"
+
+AGENT_ID=""
+TASK_SLUG=""
+DELETE_BRANCH="false"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)
+      AGENT_ID="$2"
+      shift 2
+      ;;
+    --task)
+      TASK_SLUG="$2"
+      shift 2
+      ;;
+    --delete-branch)
+      DELETE_BRANCH="true"
+      shift
+      ;;
+    *)
+      fail "Unknown argument [$1]."
+      ;;
+  esac
+done
+
+[[ -n "$AGENT_ID" ]] || fail "--agent is required."
+[[ -n "$TASK_SLUG" ]] || fail "--task is required."
+validate_agent_id "$AGENT_ID"
+validate_task_slug "$TASK_SLUG"
+require_command git
+require_primary_checkout_context
+
+BRANCH_NAME="$(branch_name_for_task "$AGENT_ID" "$TASK_SLUG")"
+WORKTREE_PATH="$(worktree_path_for_task "$AGENT_ID" "$TASK_SLUG")"
+REMOVED_WORKTREE="false"
+DELETED_BRANCH="false"
+
+if [[ -d "$WORKTREE_PATH" ]]; then
+  git worktree remove --force "$WORKTREE_PATH" >/dev/null
+  REMOVED_WORKTREE="true"
+fi
+
+if [[ "$DELETE_BRANCH" == "true" ]] && git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  git branch -D "$BRANCH_NAME" >/dev/null
+  DELETED_BRANCH="true"
+fi
+
+AGENT_ID="$AGENT_ID" \
+TASK_SLUG="$TASK_SLUG" \
+BRANCH_NAME="$BRANCH_NAME" \
+WORKTREE_PATH="$WORKTREE_PATH" \
+DELETE_BRANCH="$DELETE_BRANCH" \
+REMOVED_WORKTREE="$REMOVED_WORKTREE" \
+DELETED_BRANCH="$DELETED_BRANCH" \
+python3 - <<'PY'
+import json
+import os
+
+print(
+    json.dumps(
+        {
+            "agent_id": os.environ["AGENT_ID"],
+            "task_slug": os.environ["TASK_SLUG"],
+            "branch_name": os.environ["BRANCH_NAME"],
+            "worktree_path": os.environ["WORKTREE_PATH"],
+            "delete_branch_requested": os.environ["DELETE_BRANCH"] == "true",
+            "removed_worktree": os.environ["REMOVED_WORKTREE"] == "true",
+            "deleted_branch": os.environ["DELETED_BRANCH"] == "true",
+        },
+        indent=2,
+    )
+)
+PY

--- a/scripts/dev-worktree/status.sh
+++ b/scripts/dev-worktree/status.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THIS_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/dev_vm_common.sh
+source "$THIS_SCRIPT_DIR/../dev_vm_common.sh"
+
+parse_agent_task_and_base "$@"
+require_command git
+require_primary_checkout_context
+
+BRANCH_NAME="$(branch_name_for_task "$AGENT_ID" "$TASK_SLUG")"
+WORKTREE_PATH="$(worktree_path_for_task "$AGENT_ID" "$TASK_SLUG")"
+BRANCH_EXISTS="false"
+WORKTREE_EXISTS="false"
+PATH_IS_WORKTREE="false"
+WORKTREE_BRANCH=""
+WORKTREE_DIRTY="false"
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  BRANCH_EXISTS="true"
+fi
+
+if [[ -d "$WORKTREE_PATH" ]]; then
+  WORKTREE_EXISTS="true"
+  if git -C "$WORKTREE_PATH" rev-parse --show-toplevel >/dev/null 2>&1; then
+    PATH_IS_WORKTREE="true"
+    WORKTREE_BRANCH="$(git -C "$WORKTREE_PATH" branch --show-current)"
+    if [[ -n "$(git -C "$WORKTREE_PATH" status --short)" ]]; then
+      WORKTREE_DIRTY="true"
+    fi
+  fi
+fi
+
+AGENT_ID="$AGENT_ID" \
+TASK_SLUG="$TASK_SLUG" \
+BRANCH_NAME="$BRANCH_NAME" \
+WORKTREE_PATH="$WORKTREE_PATH" \
+PRIMARY_CHECKOUT_PATH="$PRIMARY_CHECKOUT_PATH" \
+BRANCH_EXISTS="$BRANCH_EXISTS" \
+WORKTREE_EXISTS="$WORKTREE_EXISTS" \
+PATH_IS_WORKTREE="$PATH_IS_WORKTREE" \
+WORKTREE_BRANCH="$WORKTREE_BRANCH" \
+WORKTREE_DIRTY="$WORKTREE_DIRTY" \
+python3 - <<'PY'
+import json
+import os
+
+print(
+    json.dumps(
+        {
+            "agent_id": os.environ["AGENT_ID"],
+            "task_slug": os.environ["TASK_SLUG"],
+            "branch_name": os.environ["BRANCH_NAME"],
+            "worktree_path": os.environ["WORKTREE_PATH"],
+            "primary_checkout_path": os.environ["PRIMARY_CHECKOUT_PATH"],
+            "branch_exists": os.environ["BRANCH_EXISTS"] == "true",
+            "worktree_exists": os.environ["WORKTREE_EXISTS"] == "true",
+            "path_is_worktree": os.environ["PATH_IS_WORKTREE"] == "true",
+            "worktree_branch": os.environ["WORKTREE_BRANCH"],
+            "worktree_dirty": os.environ["WORKTREE_DIRTY"] == "true",
+        },
+        indent=2,
+    )
+)
+PY

--- a/scripts/dev_vm_client_shell.sh
+++ b/scripts/dev_vm_client_shell.sh
@@ -8,7 +8,9 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 parse_agent_and_python "$@"
 require_local_prereqs
 require_command zsh
+require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
+validate_loaded_state_against_current_context
 
 uv python install "$PYTHON_VERSION" >/dev/null 2>&1
 uv python pin --project "$CLIENT_PROJECT" "$PYTHON_VERSION" >/dev/null 2>&1

--- a/scripts/dev_vm_common.sh
+++ b/scripts/dev_vm_common.sh
@@ -35,6 +35,7 @@ require_command() {
 
 require_local_prereqs() {
   require_command gcloud
+  require_command git
   require_command python3
   require_command scp
   require_command ssh
@@ -46,6 +47,11 @@ require_local_prereqs() {
 validate_agent_id() {
   local agent_id="$1"
   [[ "$agent_id" =~ ^[0-9]{2}$ ]] || fail "--agent must be a two-digit string like [01]."
+}
+
+validate_task_slug() {
+  local task_slug="$1"
+  [[ "$task_slug" =~ ^[a-z0-9][a-z0-9-]*$ ]] || fail "--task must be lower-case letters, numbers, and hyphens."
 }
 
 parse_agent_only() {
@@ -88,6 +94,37 @@ parse_agent_and_python() {
   [[ -n "$AGENT_ID" ]] || fail "--agent is required."
   [[ -n "$PYTHON_VERSION" ]] || fail "--python is required."
   validate_agent_id "$AGENT_ID"
+}
+
+parse_agent_task_and_base() {
+  AGENT_ID=""
+  TASK_SLUG=""
+  BASE_REF="${BURLA_DEV_WORKTREE_BASE_REF:-main}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        AGENT_ID="$2"
+        shift 2
+        ;;
+      --task)
+        TASK_SLUG="$2"
+        shift 2
+        ;;
+      --base)
+        BASE_REF="$2"
+        shift 2
+        ;;
+      *)
+        fail "Unknown argument [$1]."
+        ;;
+    esac
+  done
+
+  [[ -n "$AGENT_ID" ]] || fail "--agent is required."
+  [[ -n "$TASK_SLUG" ]] || fail "--task is required."
+  [[ -n "$BASE_REF" ]] || fail "--base must not be empty."
+  validate_agent_id "$AGENT_ID"
+  validate_task_slug "$TASK_SLUG"
 }
 
 parse_agent_and_destroy_flags() {
@@ -156,6 +193,41 @@ public_key_path_for_agent() {
 
 timestamp_utc() {
   date -u +%Y%m%dt%H%M%S
+}
+
+current_git_toplevel() {
+  git rev-parse --show-toplevel
+}
+
+current_git_branch() {
+  git branch --show-current
+}
+
+primary_checkout_path() {
+  git worktree list --porcelain | awk '/^worktree /{print substr($0, 10); exit}'
+}
+
+branch_name_for_task() {
+  local agent_id="$1"
+  local task_slug="$2"
+  echo "agent/${agent_id}/${task_slug}"
+}
+
+worktree_base_dir() {
+  if [[ -n "${BURLA_DEV_WORKTREE_BASE_DIR:-}" ]]; then
+    echo "$BURLA_DEV_WORKTREE_BASE_DIR"
+    return
+  fi
+
+  local primary_checkout
+  primary_checkout="$(primary_checkout_path)"
+  echo "$(dirname "$primary_checkout")/burla-worktrees"
+}
+
+worktree_path_for_task() {
+  local agent_id="$1"
+  local task_slug="$2"
+  echo "$(worktree_base_dir)/agent-${agent_id}/${task_slug}"
 }
 
 main_service_service_account() {
@@ -329,4 +401,47 @@ rendered = rendered.replace("__REMOTE_LOG_PATH__", os.environ["REMOTE_LOG_PATH"]
 rendered = rendered.replace("__BOOTSTRAP_READY_PATH__", os.environ["BOOTSTRAP_READY_PATH"])
 pathlib.Path(sys.argv[2]).write_text(rendered)
 PY
+}
+
+require_primary_checkout_context() {
+  local current_checkout
+  local primary_checkout
+
+  current_checkout="$(current_git_toplevel)"
+  primary_checkout="$(primary_checkout_path)"
+  [[ "$current_checkout" == "$primary_checkout" ]] || fail "Run this from the primary checkout [$primary_checkout], not from linked worktree [$current_checkout]."
+
+  CURRENT_CHECKOUT_PATH="$current_checkout"
+  PRIMARY_CHECKOUT_PATH="$primary_checkout"
+}
+
+require_agent_worktree_context() {
+  local expected_agent_id="$1"
+  local current_checkout
+  local primary_checkout
+  local branch_name
+  local branch_regex
+
+  current_checkout="$(current_git_toplevel)"
+  primary_checkout="$(primary_checkout_path)"
+  [[ "$current_checkout" != "$primary_checkout" ]] || fail "Run this from a linked worktree, not the primary checkout [$primary_checkout]."
+
+  branch_name="$(current_git_branch)"
+  branch_regex="^agent/${expected_agent_id}/([a-z0-9][a-z0-9-]*)$"
+  [[ "$branch_name" =~ $branch_regex ]] || fail "Current branch [$branch_name] must match [agent/${expected_agent_id}/<task-slug>]."
+
+  CURRENT_CHECKOUT_PATH="$current_checkout"
+  PRIMARY_CHECKOUT_PATH="$primary_checkout"
+  CURRENT_BRANCH_NAME="$branch_name"
+  CURRENT_TASK_SLUG="${BASH_REMATCH[1]}"
+  CURRENT_WORKTREE_PATH="$current_checkout"
+}
+
+validate_loaded_state_against_current_context() {
+  [[ -n "${BRANCH_NAME:-}" ]] || fail "State file [$STATE_PATH] is missing [branch_name]."
+  [[ -n "${TASK_SLUG:-}" ]] || fail "State file [$STATE_PATH] is missing [task_slug]."
+  [[ -n "${WORKTREE_PATH:-}" ]] || fail "State file [$STATE_PATH] is missing [worktree_path]."
+  [[ "$BRANCH_NAME" == "$CURRENT_BRANCH_NAME" ]] || fail "State branch [$BRANCH_NAME] does not match current branch [$CURRENT_BRANCH_NAME]."
+  [[ "$TASK_SLUG" == "$CURRENT_TASK_SLUG" ]] || fail "State task [$TASK_SLUG] does not match current task [$CURRENT_TASK_SLUG]."
+  [[ "$WORKTREE_PATH" == "$CURRENT_WORKTREE_PATH" ]] || fail "State worktree [$WORKTREE_PATH] does not match current worktree [$CURRENT_WORKTREE_PATH]."
 }

--- a/scripts/dev_vm_create.sh
+++ b/scripts/dev_vm_create.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_only "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 ensure_state_dir
 ensure_agent_keypair "$AGENT_ID"
 
@@ -109,6 +110,10 @@ PATCH_JSON="$(
   DASHBOARD_URL="http://localhost:${LOCAL_DASHBOARD_PORT}" \
   REMOTE_LOG_PATH="$REMOTE_LOG_PATH" \
   REMOTE_TMUX_SESSION="$REMOTE_TMUX_SESSION" \
+  BRANCH_NAME="$CURRENT_BRANCH_NAME" \
+  TASK_SLUG="$CURRENT_TASK_SLUG" \
+  WORKTREE_PATH="$CURRENT_WORKTREE_PATH" \
+  PRIMARY_CHECKOUT_PATH="$PRIMARY_CHECKOUT_PATH" \
   LOCAL_USER="$LOCAL_USER" \
   VM_IP="$VM_IP" \
   PRIVATE_KEY_PATH="$PRIVATE_KEY_PATH" \
@@ -131,6 +136,10 @@ print(
             "tunnel_pid": None,
             "remote_log_path": os.environ["REMOTE_LOG_PATH"],
             "remote_tmux_session": os.environ["REMOTE_TMUX_SESSION"],
+            "branch_name": os.environ["BRANCH_NAME"],
+            "task_slug": os.environ["TASK_SLUG"],
+            "worktree_path": os.environ["WORKTREE_PATH"],
+            "primary_checkout_path": os.environ["PRIMARY_CHECKOUT_PATH"],
             "local_user": os.environ["LOCAL_USER"],
             "vm_ip": os.environ["VM_IP"],
             "private_key_path": os.environ["PRIVATE_KEY_PATH"],

--- a/scripts/dev_vm_destroy.sh
+++ b/scripts/dev_vm_destroy.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_and_destroy_flags "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 
 STATE_PATH="$(state_path_for_agent "$AGENT_ID")"
 PROJECT_ID="$(project_id_for_agent "$AGENT_ID")"
@@ -16,6 +17,7 @@ TUNNEL_PID=""
 
 if [[ -f "$STATE_PATH" ]]; then
   load_state_vars "$AGENT_ID"
+  validate_loaded_state_against_current_context
 fi
 
 if [[ -n "${TUNNEL_PID:-}" ]] && kill -0 "$TUNNEL_PID" >/dev/null 2>&1; then

--- a/scripts/dev_vm_start_local_dev.sh
+++ b/scripts/dev_vm_start_local_dev.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_only "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
+validate_loaded_state_against_current_context
 
 REMOTE_BODY="$(cat <<EOF
 cat > /tmp/burla-start-local-dev.sh <<'INNER'
@@ -15,6 +17,8 @@ cat > /tmp/burla-start-local-dev.sh <<'INNER'
 set -euo pipefail
 CLOUDSDK_CORE_PROJECT='$PROJECT_ID' gcloud auth configure-docker us-docker.pkg.dev --quiet >/dev/null
 cd '$REMOTE_REPO_DIR/main_service'
+make build-frontend
+test -f .frontend_last_built_at.txt || printf '%s' "$(date +%s)" > .frontend_last_built_at.txt
 CLOUDSDK_CORE_PROJECT='$PROJECT_ID' make image
 tmux kill-session -t '$REMOTE_TMUX_SESSION' >/dev/null 2>&1 || true
 docker rm -f main_service >/dev/null 2>&1 || true

--- a/scripts/dev_vm_status.sh
+++ b/scripts/dev_vm_status.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_only "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
+validate_loaded_state_against_current_context
 
 VM_EXISTS="false"
 REMOTE_SESSION_RUNNING="false"
@@ -45,6 +47,10 @@ DASHBOARD_URL="$DASHBOARD_URL" \
 TUNNEL_PID="${TUNNEL_PID:-}" \
 REMOTE_LOG_PATH="$REMOTE_LOG_PATH" \
 REMOTE_TMUX_SESSION="$REMOTE_TMUX_SESSION" \
+BRANCH_NAME="${BRANCH_NAME:-}" \
+TASK_SLUG="${TASK_SLUG:-}" \
+WORKTREE_PATH="${WORKTREE_PATH:-}" \
+PRIMARY_CHECKOUT_PATH="${PRIMARY_CHECKOUT_PATH:-}" \
 LOCAL_USER="$LOCAL_USER" \
 VM_IP="$VM_IP" \
 VM_EXISTS="$VM_EXISTS" \
@@ -70,6 +76,10 @@ print(
             "tunnel_pid": int(os.environ["TUNNEL_PID"]) if os.environ.get("TUNNEL_PID") else None,
             "remote_log_path": os.environ["REMOTE_LOG_PATH"],
             "remote_tmux_session": os.environ["REMOTE_TMUX_SESSION"],
+            "branch_name": os.environ["BRANCH_NAME"],
+            "task_slug": os.environ["TASK_SLUG"],
+            "worktree_path": os.environ["WORKTREE_PATH"],
+            "primary_checkout_path": os.environ["PRIMARY_CHECKOUT_PATH"],
             "local_user": os.environ["LOCAL_USER"],
             "vm_ip": os.environ["VM_IP"],
             "vm_exists": os.environ["VM_EXISTS"] == "true",

--- a/scripts/dev_vm_sync_repo.sh
+++ b/scripts/dev_vm_sync_repo.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_only "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
+validate_loaded_state_against_current_context
 
 SYNC_ARCHIVE="$(mktemp "/tmp/burla-dev-vm-${AGENT_ID}-XXXXXX.tgz")"
 REMOTE_ARCHIVE="burla-dev-vm-${AGENT_ID}.tgz"

--- a/scripts/dev_vm_tunnel.sh
+++ b/scripts/dev_vm_tunnel.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_only "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
+validate_loaded_state_against_current_context
 
 if [[ -n "${TUNNEL_PID:-}" ]] && kill -0 "$TUNNEL_PID" >/dev/null 2>&1; then
   kill "$TUNNEL_PID" >/dev/null 2>&1 || true

--- a/scripts/dev_vm_wait_ssh.sh
+++ b/scripts/dev_vm_wait_ssh.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/dev_vm_common.sh"
 
 parse_agent_only "$@"
 require_local_prereqs
+require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
+validate_loaded_state_against_current_context
 
 MAX_ATTEMPTS="${BURLA_DEV_VM_WAIT_ATTEMPTS:-120}"
 SLEEP_SECONDS="${BURLA_DEV_VM_WAIT_SLEEP_SECONDS:-5}"


### PR DESCRIPTION
## Summary
- add small `scripts/dev-worktree/*` helpers so Burla agent tasks start from fresh linked worktrees and task branches instead of editing the primary checkout
- make the existing dev-vm workflow enforce worktree usage, record branch/worktree metadata in VM state, and keep syncing the active worktree snapshot rather than a shared local checkout
- update the Burla dev-VM skill/rule and remote startup path so the worktree-first flow is documented and `local-dev` still boots correctly from worktree-synced VM snapshots

## Test plan
- [x] Run `bash -n` across the updated `scripts/dev_vm_*` files and the new `scripts/dev-worktree/*` helpers
- [x] Verify `scripts/dev_vm_create.sh --agent 01` fails from the primary checkout
- [x] Create linked worktrees `agent/01/validate-a` and `agent/02/validate-b`, make distinct local edits, and verify the main checkout stays unchanged and the worktrees do not see each other’s files
- [x] From each linked worktree, provision a separate Burla local-dev VM, sync the worktree snapshot, start `local-dev`, tunnel `localhost:15001` and `localhost:15002`, and verify both dashboards return HTTP 200
- [x] Verify VM 01 only contains `agent-01-validation.txt` and VM 02 only contains `agent-02-validation.txt`
- [x] Destroy both VMs, verify both tunnels are down, and verify both cloud instances are gone


Made with [Cursor](https://cursor.com)