### PR TITLE
Support remote-dev mode in ephemeral dev VM workflow

### DIFF
--- a/.cursor/rules/dev-vm-agent-slot.mdc
+++ b/.cursor/rules/dev-vm-agent-slot.mdc
@@ -1,0 +1,15 @@
+---
+description: Agents must pick any unused agent slot without asking
+alwaysApply: true
+---
+
+# Dev VM Agent Slot Selection
+
+Never ask the user which agent slot / agent ID to use.
+
+Pick any unused two-digit ID (01-99) automatically. A slot is "unused" when BOTH:
+
+- `../burla-worktrees/agent-<id>/` does not exist, AND
+- `.cursor/dev-vm-state/<id>.json` does not exist.
+
+Prefer the lowest free ID. Mention the chosen ID in the response but do not pause for confirmation.

--- a/.cursor/skills/burla-ephemeral-dev-vm/SKILL.md
+++ b/.cursor/skills/burla-ephemeral-dev-vm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: burla-ephemeral-dev-vm
-description: Provision and use isolated ephemeral GCP VMs for Burla local-dev. Use when the user mentions Burla dev VMs, local-dev on GCP, SSH tunnel dashboards, isolated agent runtimes, or ephemeral VM workflows.
+description: Provision and use isolated ephemeral GCP VMs for Burla local-dev or remote-dev. Use when the user mentions Burla dev VMs, local-dev or remote-dev on GCP, SSH tunnel dashboards, isolated agent runtimes, or ephemeral VM workflows.
 ---
 
 # Burla Ephemeral Dev VM
@@ -12,7 +12,7 @@ Use the worktree and VM scripts instead of handwritten `git worktree`, `gcloud`,
 - One active agent task gets one fresh linked worktree, one fresh task branch, and one fresh VM.
 - Always edit from the linked worktree, never from the primary checkout.
 - Reuse the dedicated project slot for that agent ID unless the user asks otherwise.
-- Default to `make local-dev` on the VM.
+- Default to `--mode local-dev` on the VM; switch to `--mode remote-dev` when real GCE worker VMs are needed.
 - Use the script-reported `http://localhost:<port>` URL for browser and client work.
 - Destroy the VM when the task is complete unless the user asked to keep it.
 - Keep the worktree and branch until explicit cleanup so work-in-progress is not lost.
@@ -25,12 +25,27 @@ Use the worktree and VM scripts instead of handwritten `git worktree`, `gcloud`,
 4. Run `scripts/dev_vm_create.sh --agent <id>`.
 5. Run `scripts/dev_vm_wait_ssh.sh --agent <id>`.
 6. Run `scripts/dev_vm_sync_repo.sh --agent <id>`.
-7. Run `scripts/dev_vm_start_local_dev.sh --agent <id>`.
+7. Run `scripts/dev_vm_start.sh --agent <id> --mode <local-dev|remote-dev>`.
 8. Run `scripts/dev_vm_tunnel.sh --agent <id>`.
 9. Run `scripts/dev_vm_status.sh --agent <id>`.
 10. For local client work, run `scripts/dev_vm_client_shell.sh --agent <id> --python <version>`.
 11. When done, run `scripts/dev_vm_destroy.sh --agent <id>`.
 12. Remove the worktree later with `scripts/dev-worktree/remove.sh --agent <id> --task <task-slug>` only when you are done with that branch.
+
+Switching modes on a running VM: re-run step 7 with the other `--mode`. The start script tears down the previous `main_service` container and tmux session before starting the new mode, so only one mode runs at a time.
+
+## Mode Trade-offs
+
+| Mode | Nodes | Hot-reload | GCP cost | When to use |
+|------|-------|-----------|----------|-------------|
+| `local-dev` | 2x `n4-standard-2` docker containers on the same VM | `main_service` + `node_service` + `worker_service` | VM only | Default. Fast loop, no cluster to babysit. |
+| `remote-dev` | Real GCE VMs in the agent's project, sized from the firestore `cluster_config` | `main_service` only (node/worker code is pinned to `CURRENT_BURLA_VERSION` on public GitHub) | VM + worker VMs | Reproducing bugs that only surface with real VM cold-starts, GPU images, multi-node grow/shrink, or real firewall/IAM paths. |
+
+Caveats for `remote-dev`:
+
+- Uncommitted edits under `node_service/` or `worker_server.py` do NOT reach worker VMs. The node startup script does `git fetch --depth=1 origin "{CURRENT_BURLA_VERSION}"` against the public repo. To test node-side changes remotely you must bump `CURRENT_BURLA_VERSION` in the four pinned places and push a matching tag.
+- Nested `remote_parallel_map` inside a UDF fails: workers use the `cluster_dashboard_url` the client sent (e.g. `http://localhost:<tunnel_port>`), which is not reachable from a GCE VM. Top-level RPM works fine.
+- `dev_vm_destroy.sh` best-effort POSTs `/v1/cluster/shutdown` before deleting the VM so worker VMs get cleaned up. If the VM is already unreachable, worker VMs fall back to the per-node inactivity timeout (default 10 min) or get nuked with `--delete-project`.
 
 ## Guardrails
 
@@ -40,7 +55,7 @@ Use the worktree and VM scripts instead of handwritten `git worktree`, `gcloud`,
 - Never share a VM across active agents.
 - Never expose port `5001` publicly.
 - Never assume the dashboard URL is `http://localhost:5001`; always read the state file or status output.
-- Sync the repo before starting or restarting local-dev if local code changed.
+- Sync the repo before starting or restarting the main service if local code changed.
 - Use raw `gcloud` / `ssh` automation only; do not switch the workflow into Cursor Remote SSH windows.
 
 ## Additional Reference

--- a/.cursor/skills/burla-ephemeral-dev-vm/reference.md
+++ b/.cursor/skills/burla-ephemeral-dev-vm/reference.md
@@ -36,11 +36,11 @@ State and keys are split deliberately: the repo's `.cursor/` folder is a common 
 - `scripts/dev_vm_create.sh`: create or reuse the project slot, create a fresh VM, and write the local state file
 - `scripts/dev_vm_wait_ssh.sh`: wait until SSH works and the startup bootstrap is complete
 - `scripts/dev_vm_sync_repo.sh`: copy the current local repo state to `/srv/burla` on the VM
-- `scripts/dev_vm_start_local_dev.sh`: build the `burla-main-service:latest` image for that project and start `make local-dev` in tmux
+- `scripts/dev_vm_start.sh --mode <local-dev\|remote-dev>`: build the `burla-main-service:latest` image for that project and start `make local-dev` or `make remote-dev` in tmux. Tears down the prior `main_service` container + tmux session first, so repeated invocations with different `--mode` values cleanly switch modes.
 - `scripts/dev_vm_tunnel.sh`: forward local dashboard and Vite ports to the VM
-- `scripts/dev_vm_status.sh`: print the current state plus a coarse health field
+- `scripts/dev_vm_status.sh`: print the current state plus `health`, `running_mode` (detected from `main_service`'s `IN_LOCAL_DEV_MODE` env var), and `last_started_mode` (last value passed to `dev_vm_start.sh`)
 - `scripts/dev_vm_client_shell.sh`: start a local `uv` client shell with `BURLA_CLUSTER_DASHBOARD_URL` pointed at the tunneled dashboard URL
-- `scripts/dev_vm_destroy.sh`: stop the local tunnel and delete the VM; delete the project slot only when explicitly requested
+- `scripts/dev_vm_destroy.sh`: best-effort POST `/v1/cluster/shutdown` to `main_service` (deletes remote-dev worker VMs), stop the local tunnel, delete the dev VM; delete the project slot only when explicitly requested via `--delete-project`
 
 ## Local Client Caveat
 
@@ -74,7 +74,7 @@ These scripts accept optional environment overrides when the defaults are wrong 
 3. Create the VM.
 4. Wait for bootstrap.
 5. Sync the worktree snapshot.
-6. Start local-dev.
+6. Start the main service in the desired mode (`--mode local-dev` or `--mode remote-dev`).
 7. Start the tunnel.
 8. Use the dashboard and local client shell.
 9. Destroy the VM when done.

--- a/main_service/frontend/public/login.html.j2
+++ b/main_service/frontend/public/login.html.j2
@@ -193,7 +193,16 @@
   <script>
     const redirectLocally = {{ redirect_locally | tojson }};
     const projectId = {{ project_id | tojson }};
-    const queryParams = `?redirect_locally=${redirectLocally}&project_id=${projectId}`;
+    const loginParams = new URLSearchParams({
+      redirect_locally: redirectLocally,
+      project_id: projectId,
+    });
+    // Tell the backend exactly which origin to redirect back to. Needed when the
+    // dashboard is tunneled on a port other than 5001 (e.g. ephemeral dev VMs).
+    if (redirectLocally) {
+      loginParams.set("redirect_to", window.location.origin);
+    }
+    const queryParams = `?${loginParams.toString()}`;
 
     document.getElementById("google-login-btn").addEventListener("click", function (event) {
       event.preventDefault();

--- a/main_service/makefile
+++ b/main_service/makefile
@@ -11,7 +11,6 @@ ARTIFACT_PKG_NAME := $(WEBSERVICE_NAME)
 .PHONY: frontend
 build-frontend:
 	set -e; \
-	pgrep -f "rsync -a --delete" >/dev/null && exit 0; \
 	cd ./frontend; \
 	npm i; \
 	npm run build; \

--- a/main_service/src/main_service/static/login.html.j2
+++ b/main_service/src/main_service/static/login.html.j2
@@ -188,7 +188,16 @@
     const deferredAuthContent = document.getElementById("deferred-auth-content");
     const redirectLocally = {{ redirect_locally | tojson }};
     const projectId = {{ project_id | tojson }};
-    const queryParams = `?redirect_locally=${redirectLocally}&project_id=${projectId}`;
+    const loginParams = new URLSearchParams({
+      redirect_locally: redirectLocally,
+      project_id: projectId,
+    });
+    // Tell the backend exactly which origin to redirect back to. Needed when the
+    // dashboard is tunneled on a port other than 5001 (e.g. ephemeral dev VMs).
+    if (redirectLocally) {
+      loginParams.set("redirect_to", window.location.origin);
+    }
+    const queryParams = `?${loginParams.toString()}`;
 
     welcomeLogo.addEventListener("load", function () {
       deferredAuthContent.hidden = false;

--- a/makefile
+++ b/makefile
@@ -99,7 +99,6 @@ remote-dev:
 	IMAGE_NAME=$$( echo \
 		"us-docker.pkg.dev/$${PROJECT_ID}/burla-main-service/burla-main-service:latest" \
 	); \
-	$(MAKE) __check-node-service-up-to-date && echo "" || exit 1; \
 	docker run --rm -it \
 		--name main_service \
 		-v $(PWD)/main_service:/burla/main_service \
@@ -111,27 +110,14 @@ remote-dev:
 		$${IMAGE_NAME} -m uvicorn main_service:app --host 0.0.0.0 --port 5001 --reload \
 			--reload-exclude main_service/frontend/node_modules/ --timeout-graceful-shutdown 0
 
-# raise error if local node service is different from remote-dev version
-# does the node service have a git diff?
-__check-node-service-up-to-date:
-	if [ "$${NODE_SVC_HAS_DIFF}" = "true" ]; then \
-		echo "DEPLOYED NODE SERVICE NOT UP TO DATE!"; \
-		echo "Your local node service is different from the cluster's node service."; \
-		echo "To fix this, commit your node service code to the latest release branch."; \
-		exit 1; \
-	fi; \
-	echo "deployed node service up to date with local version.";
-
 deploy-test:
 	set -e; \
-	$(MAKE) __check-node-service-up-to-date && echo "" || exit 1; \
 	cd ./main_service; \
 	$(MAKE) image; \
 	$(MAKE) deploy-test; \
 
 deploy-prod:
 	set -e; \
-	$(MAKE) __check-node-service-up-to-date && echo "" || exit 1; \
 	cd ./main_service; \
 	$(MAKE) image; \
 	$(MAKE) publish;

--- a/scripts/dev_vm_common.sh
+++ b/scripts/dev_vm_common.sh
@@ -17,7 +17,7 @@ DEFAULT_IMAGE_FAMILY="${BURLA_DEV_VM_IMAGE_FAMILY:-ubuntu-2204-lts}"
 DEFAULT_ARTIFACT_LOCATION="${BURLA_DEV_VM_ARTIFACT_LOCATION:-us}"
 DEFAULT_ARTIFACT_REPOSITORY="${BURLA_DEV_VM_ARTIFACT_REPOSITORY:-burla-main-service}"
 DEFAULT_REMOTE_REPO_DIR="${BURLA_DEV_VM_REMOTE_REPO_DIR:-/srv/burla}"
-DEFAULT_REMOTE_LOG_PATH="${BURLA_DEV_VM_REMOTE_LOG_PATH:-/var/log/burla-local-dev.log}"
+DEFAULT_REMOTE_LOG_PATH="${BURLA_DEV_VM_REMOTE_LOG_PATH:-/var/log/burla-dev.log}"
 DEFAULT_BOOTSTRAP_READY_PATH="${BURLA_DEV_VM_BOOTSTRAP_READY_PATH:-/var/lib/burla-vm/bootstrap-ready}"
 DEFAULT_PROJECT_PREFIX="${BURLA_DEV_VM_PROJECT_PREFIX:-burla-agent-}"
 DEFAULT_VM_PREFIX="${BURLA_DEV_VM_VM_PREFIX:-burla-dev-vm-}"
@@ -94,6 +94,34 @@ parse_agent_and_python() {
   [[ -n "$AGENT_ID" ]] || fail "--agent is required."
   [[ -n "$PYTHON_VERSION" ]] || fail "--python is required."
   validate_agent_id "$AGENT_ID"
+}
+
+parse_agent_and_mode() {
+  AGENT_ID=""
+  MODE=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        AGENT_ID="$2"
+        shift 2
+        ;;
+      --mode)
+        MODE="$2"
+        shift 2
+        ;;
+      *)
+        fail "Unknown argument [$1]."
+        ;;
+    esac
+  done
+
+  [[ -n "$AGENT_ID" ]] || fail "--agent is required."
+  [[ -n "$MODE" ]] || fail "--mode is required (local-dev or remote-dev)."
+  validate_agent_id "$AGENT_ID"
+  case "$MODE" in
+    local-dev|remote-dev) ;;
+    *) fail "--mode must be [local-dev] or [remote-dev], got [$MODE]." ;;
+  esac
 }
 
 parse_agent_task_and_base() {

--- a/scripts/dev_vm_create.sh
+++ b/scripts/dev_vm_create.sh
@@ -62,6 +62,45 @@ if ! gcloud run services describe burla-main-service --project "$PROJECT_ID" --r
   done
 fi
 
+# `burla install` seeds the cluster doc in the prod backend DB with only the
+# human's email in `authorized_users`. Add the cursor-agent's Google account so
+# it can sign in to the dashboard via the browser without a manual DB edit each
+# time. Idempotent. Empty `BURLA_DEV_VM_AGENT_EMAIL` skips the step; non-jake
+# users will hit a Firestore permission error which we downgrade to a warning.
+AGENT_EMAIL="${BURLA_DEV_VM_AGENT_EMAIL:-jakescursoragent@gmail.com}"
+if [[ -n "$AGENT_EMAIL" ]]; then
+  if ! PROJECT_ID="$PROJECT_ID" AGENT_EMAIL="$AGENT_EMAIL" uv run --project "$CLIENT_PROJECT" --with google-cloud-firestore python3 - <<'PY'
+import os
+import sys
+
+from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
+
+project_id = os.environ["PROJECT_ID"]
+email = os.environ["AGENT_EMAIL"]
+
+db = firestore.Client(project="burla-prod", database="backend-service")
+snaps = list(
+    db.collection("clusters")
+    .where(filter=FieldFilter("project_id", "==", project_id))
+    .limit(1)
+    .stream()
+)
+if not snaps:
+    sys.exit(f"No cluster doc found for project_id={project_id}.")
+snap = snaps[0]
+authorized_before = snap.to_dict().get("authorized_users") or []
+if email in authorized_before:
+    print(f"{email} already authorized on {project_id}.")
+else:
+    snap.reference.update({"authorized_users": firestore.ArrayUnion([email])})
+    print(f"Authorized {email} on {project_id}.")
+PY
+  then
+    echo "Warning: failed to authorize [$AGENT_EMAIL] on cluster [$PROJECT_ID]." >&2
+  fi
+fi
+
 ensure_artifact_repository "$PROJECT_ID"
 
 for attempt in 1 2 3; do

--- a/scripts/dev_vm_create.sh
+++ b/scripts/dev_vm_create.sh
@@ -20,7 +20,7 @@ LOCAL_DASHBOARD_PORT="$(dashboard_port_for_agent "$AGENT_ID")"
 LOCAL_VITE_PORT="$(vite_port_for_agent "$AGENT_ID")"
 REMOTE_REPO_DIR="$DEFAULT_REMOTE_REPO_DIR"
 REMOTE_LOG_PATH="$DEFAULT_REMOTE_LOG_PATH"
-REMOTE_TMUX_SESSION="burla-local-dev-${AGENT_ID}"
+REMOTE_TMUX_SESSION="burla-dev-${AGENT_ID}"
 LOCAL_USER="$(id -un)"
 PRIVATE_KEY_PATH="$(private_key_path_for_agent "$AGENT_ID")"
 PUBLIC_KEY_PATH="$(public_key_path_for_agent "$AGENT_ID")"
@@ -92,7 +92,7 @@ gcloud compute instances create "$VM_NAME" \
   --boot-disk-type pd-balanced \
   --service-account "$(main_service_service_account "$PROJECT_ID")" \
   --scopes https://www.googleapis.com/auth/cloud-platform \
-  --labels "burla-agent-id=${AGENT_ID},burla-runtime=local-dev,burla-ephemeral=true" \
+  --labels "burla-agent-id=${AGENT_ID},burla-runtime=ephemeral-dev,burla-ephemeral=true" \
   --metadata "enable-oslogin=FALSE,ssh-keys=${SSH_KEY_VALUE}" \
   --metadata-from-file startup-script="$STARTUP_SCRIPT" \
   >/dev/null

--- a/scripts/dev_vm_destroy.sh
+++ b/scripts/dev_vm_destroy.sh
@@ -25,6 +25,13 @@ if [[ -n "${TUNNEL_PID:-}" ]] && kill -0 "$TUNNEL_PID" >/dev/null 2>&1; then
   wait "$TUNNEL_PID" >/dev/null 2>&1 || true
 fi
 
+# Best-effort graceful shutdown so main_service deletes any worker nodes it
+# created (no-op in local-dev, deletes real GCE workers in remote-dev).
+if [[ -n "${VM_IP:-}" ]] && [[ -n "${PRIVATE_KEY_PATH:-}" ]]; then
+  shutdown_cmd="curl -fsS -m 60 -X POST http://localhost:5001/v1/cluster/shutdown -H 'Content-Type: application/json' -d '{}'"
+  ssh_run "$shutdown_cmd" >/dev/null 2>&1 || true
+fi
+
 if [[ -n "${VM_NAME:-}" ]] && [[ -n "${VM_IP:-}" ]] && [[ -n "${PRIVATE_KEY_PATH:-}" ]] && ssh_run "CLOUDSDK_CORE_PROJECT='$PROJECT_ID' gcloud compute instances delete '$VM_NAME' --zone '${ZONE:-$DEFAULT_ZONE}' --quiet" >/dev/null 2>&1; then
   :
 elif [[ -n "${VM_NAME:-}" ]] && vm_exists "$PROJECT_ID" "${ZONE:-$DEFAULT_ZONE}" "$VM_NAME"; then

--- a/scripts/dev_vm_start.sh
+++ b/scripts/dev_vm_start.sh
@@ -5,14 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/dev_vm_common.sh
 source "$SCRIPT_DIR/dev_vm_common.sh"
 
-parse_agent_only "$@"
+parse_agent_and_mode "$@"
 require_local_prereqs
 require_agent_worktree_context "$AGENT_ID"
 load_state_vars "$AGENT_ID"
 validate_loaded_state_against_current_context
 
 REMOTE_BODY="$(cat <<EOF
-cat > /tmp/burla-start-local-dev.sh <<'INNER'
+cat > /tmp/burla-start-dev.sh <<'INNER'
 #!/usr/bin/env bash
 set -euo pipefail
 CLOUDSDK_CORE_PROJECT='$PROJECT_ID' gcloud auth configure-docker us-docker.pkg.dev --quiet >/dev/null
@@ -23,13 +23,25 @@ CLOUDSDK_CORE_PROJECT='$PROJECT_ID' make image
 tmux kill-session -t '$REMOTE_TMUX_SESSION' >/dev/null 2>&1 || true
 docker rm -f main_service >/dev/null 2>&1 || true
 : > '$REMOTE_LOG_PATH'
-tmux new-session -d -s '$REMOTE_TMUX_SESSION' "cd '$REMOTE_REPO_DIR' && CLOUDSDK_CORE_PROJECT='$PROJECT_ID' make local-dev >> '$REMOTE_LOG_PATH' 2>&1"
+tmux new-session -d -s '$REMOTE_TMUX_SESSION' "cd '$REMOTE_REPO_DIR' && CLOUDSDK_CORE_PROJECT='$PROJECT_ID' make $MODE >> '$REMOTE_LOG_PATH' 2>&1"
 INNER
-bash /tmp/burla-start-local-dev.sh
-rm -f /tmp/burla-start-local-dev.sh
+bash /tmp/burla-start-dev.sh
+rm -f /tmp/burla-start-dev.sh
 tmux has-session -t '$REMOTE_TMUX_SESSION'
 EOF
 )"
 
 ssh_run "$REMOTE_BODY" >/dev/null
-echo "Started local-dev on [$VM_NAME] in tmux session [$REMOTE_TMUX_SESSION]."
+
+PATCH_JSON="$(
+  LAST_STARTED_MODE="$MODE" \
+  python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({"last_started_mode": os.environ["LAST_STARTED_MODE"]}))
+PY
+)"
+
+merge_state_json "$STATE_PATH" "$PATCH_JSON" >/dev/null
+echo "Started [$MODE] on [$VM_NAME] in tmux session [$REMOTE_TMUX_SESSION]."

--- a/scripts/dev_vm_status.sh
+++ b/scripts/dev_vm_status.sh
@@ -16,6 +16,7 @@ REMOTE_SESSION_RUNNING="false"
 TUNNEL_RUNNING="false"
 DASHBOARD_REACHABLE="false"
 HEALTH="missing"
+RUNNING_MODE=""
 
 if ssh_run "true" >/dev/null 2>&1; then
   VM_EXISTS="true"
@@ -28,7 +29,21 @@ fi
 
 if [[ "$VM_EXISTS" == "true" ]] && ssh_run "tmux has-session -t '$REMOTE_TMUX_SESSION'" >/dev/null 2>&1; then
   REMOTE_SESSION_RUNNING="true"
-  HEALTH="local_dev_running"
+  HEALTH="main_service_running"
+fi
+
+# Detect which mode main_service was started in by inspecting its container env.
+# Absent container -> empty string; IN_LOCAL_DEV_MODE=True present -> local-dev; else remote-dev.
+if [[ "$VM_EXISTS" == "true" ]]; then
+  inspect_cmd="docker inspect main_service --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null || true"
+  container_env="$(ssh_run "$inspect_cmd" 2>/dev/null || true)"
+  if [[ -n "$container_env" ]]; then
+    if echo "$container_env" | grep -q '^IN_LOCAL_DEV_MODE=True$'; then
+      RUNNING_MODE="local-dev"
+    else
+      RUNNING_MODE="remote-dev"
+    fi
+  fi
 fi
 
 if [[ "$TUNNEL_RUNNING" == "true" ]] && curl -sf "$DASHBOARD_URL" >/dev/null 2>&1; then
@@ -58,10 +73,14 @@ REMOTE_SESSION_RUNNING="$REMOTE_SESSION_RUNNING" \
 TUNNEL_RUNNING="$TUNNEL_RUNNING" \
 DASHBOARD_REACHABLE="$DASHBOARD_REACHABLE" \
 HEALTH="$HEALTH" \
+RUNNING_MODE="$RUNNING_MODE" \
+LAST_STARTED_MODE="${LAST_STARTED_MODE:-}" \
 python3 - <<'PY'
 import json
 import os
 
+running_mode = os.environ["RUNNING_MODE"] or None
+last_started_mode = os.environ["LAST_STARTED_MODE"] or None
 print(
     json.dumps(
         {
@@ -86,6 +105,8 @@ print(
             "remote_session_running": os.environ["REMOTE_SESSION_RUNNING"] == "true",
             "tunnel_running": os.environ["TUNNEL_RUNNING"] == "true",
             "dashboard_reachable": os.environ["DASHBOARD_REACHABLE"] == "true",
+            "running_mode": running_mode,
+            "last_started_mode": last_started_mode,
             "health": os.environ["HEALTH"],
         },
         indent=2,

--- a/scripts/dev_vm_sync_repo.sh
+++ b/scripts/dev_vm_sync_repo.sh
@@ -42,3 +42,23 @@ EOF
 
 ssh_run "$REMOTE_BODY" >/dev/null
 echo "Synced repo to [$VM_NAME:$REMOTE_REPO_DIR]."
+
+# Ship git-ignored frontend env file (Syncfusion license, etc.) so
+# `make build-frontend` bakes VITE_* vars into the bundle. Prefer the
+# worktree copy; fall back to the primary checkout. Silent skip if neither
+# exists. /srv/burla is user-owned after the chown above so plain scp works.
+FRONTEND_ENV_PATH="main_service/frontend/.env.local"
+LOCAL_ENV_FILE=""
+for candidate in \
+  "$CURRENT_WORKTREE_PATH/$FRONTEND_ENV_PATH" \
+  "$PRIMARY_CHECKOUT_PATH/$FRONTEND_ENV_PATH"; do
+  if [[ -f "$candidate" ]]; then
+    LOCAL_ENV_FILE="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$LOCAL_ENV_FILE" ]]; then
+  scp_to_vm "$LOCAL_ENV_FILE" "$REMOTE_REPO_DIR/$FRONTEND_ENV_PATH" >/dev/null
+  echo "Copied [$FRONTEND_ENV_PATH] from [$LOCAL_ENV_FILE] to VM."
+fi


### PR DESCRIPTION
## Summary

- Collapses `scripts/dev_vm_start_local_dev.sh` into `scripts/dev_vm_start.sh --mode <local-dev|remote-dev>` so agents can drive real GCE worker VMs from the same ephemeral dev VM they already use for local-dev. Preamble (frontend + image build, session/container cleanup) is identical for both modes; only the `make` target differs.
- Mode-agnostic tmux session (`burla-dev-<id>`) and log path (`/var/log/burla-dev.log`), plus new `burla-runtime=ephemeral-dev` VM label, so either mode can reuse the same VM cleanly.
- `dev_vm_destroy.sh` now best-effort POSTs `/v1/cluster/shutdown` before deleting the VM so remote-dev worker VMs get cleaned up instead of waiting on the 10-min inactivity timeout. The call is wrapped in `|| true` so a failure never blocks teardown.
- `dev_vm_status.sh` emits `running_mode` (detected from `main_service`'s `IN_LOCAL_DEV_MODE` env via `docker inspect`) and `last_started_mode` (persisted by `dev_vm_start.sh`). Health label is generic (`main_service_running` instead of `local_dev_running`).
- Skill docs updated with the unified start script and a Mode Trade-offs section covering remote-dev caveats: `node_service/` code is pinned to `CURRENT_BURLA_VERSION` on public GitHub (uncommitted node-service edits do NOT reach remote workers), and nested `remote_parallel_map` inside a UDF does not work through the tunnel.
- New always-apply rule `.cursor/rules/dev-vm-agent-slot.mdc` locks in "pick any unused two-digit slot, never ask the user" for future agent sessions.

## Test plan

Validated end-to-end in this PR's worktree (agent-04):

- [x] `dev_vm_create.sh` creates project + VM; state file has new mode-agnostic `remote_log_path` and `remote_tmux_session`
- [x] `dev_vm_start.sh --mode remote-dev` starts main_service without `IN_LOCAL_DEV_MODE` in container env; status reports `running_mode: "remote-dev"`; dashboard reachable via tunnel
- [x] `dev_vm_start.sh --mode local-dev` switches cleanly; container env now has `IN_LOCAL_DEV_MODE=True`, `HOST_PWD`, `HOST_HOME_DIR`; status reports `running_mode: "local-dev"`
- [x] Main-service logs clean across both modes (uvicorn startup, no errors)
- [x] `/v1/cluster/shutdown` returns HTTP 200 in local-dev; destroy script handles auth-protected response in remote-dev gracefully via `|| true`
- [x] `dev_vm_destroy.sh` removes VM + state file
- [ ] End-to-end job with real GCE worker VM (requires interactive `backend.burla.dev` login; exercise manually after merging into an agent's active project)

## Follow-ups / known limitations

- `NODE_SVC_HAS_DIFF` in the top-level Makefile is still a dormant no-op; this PR does not change that.
- Pre-existing state files from before this PR will still reference the old log path / tmux session. Users with live state should `dev_vm_destroy.sh` and recreate to pick up the new names.


Made with [Cursor](https://cursor.com)