### PR TITLE
fix(node_service): reset SEC_NEIGHBOR_HAD_NO_INPUTS per job

### DIFF
--- a/node_service/src/node_service/job_watcher.py
+++ b/node_service/src/node_service/job_watcher.py
@@ -162,6 +162,10 @@ async def _job_watcher(
     session: aiohttp.ClientSession,
     exit_stack: list,
 ):
+    # Module-global: reset per-job so prior-job state doesn't leak in.
+    global SEC_NEIGHBOR_HAD_NO_INPUTS
+    SEC_NEIGHBOR_HAD_NO_INPUTS = 0
+
     sync_db = firestore.Client(project=PROJECT_ID, database="burla")
     job_doc = async_db.collection("jobs").document(SELF["current_job"])
     sync_job_doc = sync_db.collection("jobs").document(SELF["current_job"])


### PR DESCRIPTION
## Summary

`SEC_NEIGHBOR_HAD_NO_INPUTS` in `node_service/job_watcher.py` is a module-global that was never reset between jobs. Once a job exited via the empty-neighbor completion path (the stealer saw 60s of empty responses from its neighbor), the value stayed `>= 60` on that node. The next job registered on the same node had its very first `_job_watcher` loop iteration (~20ms after subscribe) see the stale value, an empty results queue, and idle workers, and immediately fired the "done working on job" branch — calling `reset_workers` → `reinit_node`, which cleared `SELF["current_job"]` ~150ms after `POST /jobs/{id}` returned 200. Every subsequent `POST /jobs/{id}/inputs` then returned 404 "job not found", and the client failed with `client exception: job not found` after 60 retries.

## Evidence

Reproduced repeatedly tonight in `jack-burla` on `burla-node-0d91ccfe` (n4-standard-80). Representative sequence for `check_github_batch-6noapmbASkaG`:

```
04:09:19.617  POST /jobs/check_github_batch-6noapmbASkaG             → 200 OK
04:09:19.761  "Neighbor had no extra inputs for 60s, done working on job!"
04:09:19.924  POST /jobs/check_github_batch-6noapmbASkaG/inputs      → 404 Not Found
              ... 60+ retries, all 404 ...
```

Same pattern in `check_github_batch-{RuTGrCPCRsWn,DUPBFRJ3TLCb,CJcqOojySv24}`, `score_batch-2XRhRvT2Th2H`, `upload_shards-{40tIyDkCSkmo,oZ_UascTQr-I}`, all with `fail_reason: ['client exception: job not found']`. Each time preceded by a prior job on the same node that exited via the `Neighbor had no extra inputs for 60s` path.

## Fix

Reset `SEC_NEIGHBOR_HAD_NO_INPUTS = 0` at the top of `_job_watcher`. Scopes the counter to the current job without changing the input-stealing semantics. An alternative would be to move the value into `SELF` so `REINIT_SELF` handles it, but that's more invasive for a single counter that is only read/written by these two coroutines.

## Test plan

- [ ] Unit: run a job on a single-node cluster, let it complete via the empty-neighbor path, start a second job on the same node, confirm `POST /jobs/{id}/inputs` returns 200 and inputs flow end-to-end
- [ ] Confirm existing multi-node input stealing still works (empty-neighbor timeout still triggers when the whole job is actually winding down)