### PR TITLE
main_service: don't crash lifespan on missing frontend timestamp file

### DIFF
--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -252,13 +252,19 @@ async def lifespan(app: FastAPI):
         def frontend_built_successfully(attempt=1):
             if attempt == 3:
                 return False
-            else:
+            try:
                 frontend_built_at = float(Path(".frontend_last_built_at.txt").read_text().strip())
-                frontend_rebuilt = time() - frontend_built_at < 4
-                if not frontend_rebuilt:
-                    sleep(2)  # wait a couple sec then try again (could still be building)
-                    return frontend_built_successfully(attempt=attempt + 1)
-                return True
+            except (FileNotFoundError, ValueError):
+                # File hasn't been written yet (first run / vite dev server not up)
+                # or is malformed. Treat the same as "not rebuilt recently" rather
+                # than crashing uvicorn startup.
+                sleep(2)
+                return frontend_built_successfully(attempt=attempt + 1)
+            frontend_rebuilt = time() - frontend_built_at < 4
+            if not frontend_rebuilt:
+                sleep(2)  # wait a couple sec then try again (could still be building)
+                return frontend_built_successfully(attempt=attempt + 1)
+            return True
 
         if frontend_built_successfully():
             print(f"Successfully rebuilt frontend.")


### PR DESCRIPTION
## What

`frontend_built_successfully` in the local-dev branch of `lifespan` reads `.frontend_last_built_at.txt` via `float(Path(...).read_text())` with no error handling. If the file doesn't exist — first run, vite dev server not yet up, or the file got wiped during a repo sync — the uncaught `FileNotFoundError` kills uvicorn startup and the whole cluster refuses to boot.

## UX impact

Any time `make local-dev` starts without the frontend having run, main_service exits immediately with a stack trace buried in docker logs. First-time setup on a fresh dev VM hits this every time; so does every `dev_vm_sync_repo.sh` run if the frontend build produced its timestamp earlier.

## Fix

Wrap the `float(Path(...).read_text())` in `try/except (FileNotFoundError, ValueError)` and fall through to the existing retry-up-to-3-attempts-with-2s-sleep path. If all three attempts find no file, the function returns `False` and we print the existing `FAILED to rebuild frontend?` warning without aborting startup.

One-file, 6-line change to [main_service/src/main_service/__init__.py](main_service/src/main_service/__init__.py). Prod is unaffected — the entire block is gated by `if IN_LOCAL_DEV_MODE`.