### PR TITLE
node_service: fix race between concurrent POST /jobs/{id}

### DIFF
--- a/.cursor/skills/burla-deep-dive/job-lifecycle.md
+++ b/.cursor/skills/burla-deep-dive/job-lifecycle.md
@@ -70,7 +70,7 @@ On `POST /jobs/{job_id}` arrival, the `CallHookOnJobStartMiddleware` in [node_se
 
 1. If `SELF["SHUTTING_DOWN"]` returns 503.
 2. If `SELF["RUNNING"]` or `SELF["BOOTING"]` returns 409.
-3. Otherwise wraps `receive` so `on_job_start` fires on the first `http.request` event: `SELF["RUNNING"]=True`, `SELF["current_job"]=job_id`, `SELF["reserved_for_job"]=None`, and it schedules (but does **not** await) `node_doc.update({"status":"RUNNING","current_job":job_id,"reserved_for_job":None})` as `SELF["on_job_start_task"]`. SELF is mutated synchronously so the next middleware call sees the state immediately; the Firestore write is kicked off the critical path.
+3. Otherwise fires `on_job_start(scope)` synchronously at middleware entry: `SELF["RUNNING"]=True`, `SELF["current_job"]=job_id`, `SELF["reserved_for_job"]=None`, and it schedules (but does **not** await) `node_doc.update({"status":"RUNNING","current_job":job_id,"reserved_for_job":None})` as `SELF["on_job_start_task"]`. The mutation is synchronous under the asyncio event loop (no `await` between the guard and the flip) so a second concurrent `POST /jobs/{id}` correctly sees `RUNNING=True` and 409s; the Firestore write is kicked off the critical path.
 
 Then the `execute` handler in [node_service/src/node_service/job_endpoints.py](../../../node_service/src/node_service/job_endpoints.py):
 
@@ -149,6 +149,6 @@ There are three ways a job can cancel:
 
 ## Common gotcha: the "started" race
 
-`CallHookOnJobStartMiddleware` wraps `receive` so `on_job_start` runs as soon as the request body starts arriving, not when the handler completes. This exists so uploading a large pickled function doesn't leave the node in `READY` for seconds while the client thinks it's `RUNNING`.
+`CallHookOnJobStartMiddleware` fires `on_job_start` synchronously at middleware entry (right after the SHUTTING_DOWN / RUNNING / BOOTING guard checks), before awaiting the downstream app. This exists so uploading a large pickled function doesn't leave the node in `READY` for seconds while the client thinks it's `RUNNING`, and so concurrent POST /jobs/{id} requests see each other's state flip atomically. Previously the flip was deferred into a `wrapped_receive` callback on the first `http.request` event, which left a race window where two requests could both pass the 409 guard before either had flipped SELF.
 
 If `execute` later finds no matching workers and has to roll back the node to `READY`, it must `await SELF["on_job_start_task"]` before issuing the rollback update — otherwise the pending RUNNING write can land *after* the rollback's READY write and wedge the node. See the `if not workers_to_assign` block in [job_endpoints.py](../../../node_service/src/node_service/job_endpoints.py).

--- a/node_service/src/node_service/__init__.py
+++ b/node_service/src/node_service/__init__.py
@@ -227,11 +227,14 @@ async def lifespan(app: FastAPI):
     yield
 
 
-async def on_job_start(scope, first_event):
-    # SELF is set synchronously so the middleware's next-request 409 guard and
-    # the execute endpoint's rollback (which reads SELF, not firestore) see the
-    # new state immediately. The firestore write happens in the background; the
-    # rollback awaits `on_job_start_task` so the two writes cannot race.
+def on_job_start(scope):
+    # Called synchronously from `CallHookOnJobStartMiddleware` right after the
+    # guard checks pass, no `await` between check and mutation. Python's
+    # asyncio event loop guarantees no other coroutine runs during this
+    # function, so a second concurrent POST /jobs/{id} will correctly see
+    # RUNNING=True when it re-enters the middleware guard and 409 out.
+    # Firestore write is fire-and-forget; the execute endpoint's rollback
+    # awaits `on_job_start_task` so the writes can't race.
     job_id = scope.get("path", "").split("/jobs/")[-1]
     SELF["RUNNING"] = True
     SELF["current_job"] = job_id
@@ -259,7 +262,6 @@ class CallHookOnJobStartMiddleware:
         )
 
         if is_job_execution_request:
-            started = False
             if SELF["SHUTTING_DOWN"]:
                 msg = "Node is shutting down due to inactivity."
                 return await Response(msg, status_code=503)(scope, receive, send)
@@ -267,17 +269,13 @@ class CallHookOnJobStartMiddleware:
                 msg = "Node currently running or booting, request refused."
                 return await Response(msg, status_code=409)(scope, receive, send)
 
-            async def wrapped_receive():
-                nonlocal started
-                event = await receive()
-                job_starting = event.get("type") == "http.request" and not started
+            # Atomic check-and-set: the state flip must happen here, not
+            # deferred to a wrapped_receive callback, otherwise a second
+            # concurrent POST /jobs/{id} can slip past the same guard and
+            # both requests reach `execute`, both driving the single TCP
+            # worker stream and tripping `readexactly()` concurrency errors.
+            on_job_start(scope)
 
-                if job_starting:
-                    started = True
-                    await on_job_start(scope, event)
-                return event
-
-            return await self.app(scope, wrapped_receive, send)
         return await self.app(scope, receive, send)
 
 


### PR DESCRIPTION
## What

Two concurrent `POST /jobs/{id}` requests to the same node could race past the `CallHookOnJobStartMiddleware` 409 guard. The middleware checked `SELF["RUNNING"]` synchronously, but the mutation that flipped `RUNNING=True` lived inside a `wrapped_receive` callback that ran *later* — on the first `http.request` event. In the window between "guard reads `RUNNING=False`" and "body arrives and flips `RUNNING=True`", a second request could enter, re-check, and also pass. Both reached `execute`, both drove the single TCP worker stream, and the second tripped asyncio's `readexactly() called while another coroutine is already waiting for incoming data` with a 500.

## UX impact

Any user running two `remote_parallel_map` calls at once against the same cluster can hit this — especially when `max_parallelism` is high enough that `main_service` selects both onto the same node. The second rpm returns `500 Failed to assign <node>`, and the first job is usually corrupted too (worker stream is now in an undefined state).

Surfaced during test suite work in [PR #179](https://github.com/Burla-Cloud/burla/pull/179); the concurrent-jobs scenario deliberately staggers by 2s to avoid triggering it.

## Fix

Move the `SELF` state flip from the `wrapped_receive` callback into the middleware entry itself, right after the guard checks pass. Python's asyncio event loop guarantees no other coroutine runs between a sync check and a sync assignment, so a second concurrent request now correctly sees `RUNNING=True` and 409s.

Details:
- `on_job_start` becomes a regular `def` (it had no `await`s, just one `asyncio.create_task` for the fire-and-forget Firestore write).
- The `wrapped_receive` indirection is gone — along with the `started` single-shot flag, since we fire exactly once on middleware entry.
- Existing cleanup is unchanged: `handle_errors`'s `disconnected_mid_assign` branch still resets `RUNNING=False` and `current_job=None` if the client drops before `job_watcher_task` starts.
- [`.cursor/skills/burla-deep-dive/job-lifecycle.md`](.cursor/skills/burla-deep-dive/job-lifecycle.md) updated to reflect the simpler flow.

Two-file, 34-line diff. No new behavior — tightens an existing race.