### PR TITLE
dev-vm: preserve scratch dirs during repo sync to avoid orphaned bind mounts

### DIFF
--- a/scripts/dev_vm_sync_repo.sh
+++ b/scripts/dev_vm_sync_repo.sh
@@ -31,9 +31,20 @@ COPYFILE_DISABLE=1 tar -czf "$SYNC_ARCHIVE" \
 
 scp_to_vm "$SYNC_ARCHIVE" "~/${REMOTE_ARCHIVE}" >/dev/null
 
+# Scratch dirs that `make local-dev` bind-mounts into running node
+# containers. If we `rm -rf` the whole repo dir, those dirs get
+# recreated at a fresh inode and the containers' mounts go stale —
+# the mount still resolves but every write inside the container
+# returns "Directory nonexistent", and every subsequent POST /jobs/{id}
+# 500s on `NODE_AUTH_CREDENTIALS_PATH.write_text()`. Preserve the
+# scratch dirs in place so their inodes survive the sync.
 REMOTE_BODY="$(cat <<EOF
-sudo rm -rf '$REMOTE_REPO_DIR'
 sudo mkdir -p '$REMOTE_REPO_DIR'
+sudo find '$REMOTE_REPO_DIR' -mindepth 1 -maxdepth 1 \\
+  ! -name '_node_auth' \\
+  ! -name '_shared_workspace' \\
+  ! -name '_worker_service_python_env' \\
+  -exec rm -rf {} +
 sudo tar xzf "\$HOME/${REMOTE_ARCHIVE}" -C '$REMOTE_REPO_DIR'
 sudo chown -R "\$(id -un):\$(id -gn)" '$REMOTE_REPO_DIR'
 rm -f "\$HOME/${REMOTE_ARCHIVE}"


### PR DESCRIPTION
## What

`scripts/dev_vm_sync_repo.sh` started with `sudo rm -rf /srv/burla` before extracting the new tar. That wiped `/srv/burla/_node_auth`, `/srv/burla/_shared_workspace`, and `/srv/burla/_worker_service_python_env` — which are bind-mounted into every running node container. After the sync the dirs got recreated at a new inode; the containers' mounts still pointed at the old (now-detached) inode. Inside the container `stat` showed `Links: 0` and any write returned "Directory nonexistent."

## UX impact

Any agent running `scripts/dev_vm_sync_repo.sh` while a cluster is already booted silently breaks the cluster. Every subsequent `POST /jobs/{id}` 500s on `NODE_AUTH_CREDENTIALS_PATH.write_text(...)` because the bind mount can't be written to. Only recovery is to manually `sudo mkdir -p /srv/burla/_node_auth ... && chmod 777` and then bounce every node container — which I hit multiple times while writing the test scenarios in PR #179.

## Fix

Switch from `rm -rf $REMOTE_REPO_DIR` + `mkdir` + `tar xzf` to `find -mindepth 1 -maxdepth 1 ! -name <scratch dir> ... -exec rm -rf` so the three scratch dirs survive the sync with their inodes intact. Files overwritten by the tar extraction update in place via their existing inodes; running containers' bind mounts keep working.

Single 12-line change in [scripts/dev_vm_sync_repo.sh](scripts/dev_vm_sync_repo.sh). Bash-syntax-checked locally; end-to-end verification requires a running cluster + a sync, which is doable but deferred.