### PR TITLE
burla install: copy burla-node-service image to user's Artifact Registry

### DIFF
--- a/client/src/burla/_install.py
+++ b/client/src/burla/_install.py
@@ -114,6 +114,11 @@ def _install(spinner):
 
     cluster_id_token = _register_cluster_and_save_cluster_id_token(spinner, PROJECT_ID)
 
+    # Copy the node-service image into the user's Artifact Registry so local-dev
+    # (and any Node.start path that references `{PROJECT_ID}/burla-node-service`)
+    # can pull it.
+    _copy_node_service_image_to_user_project(spinner, PROJECT_ID)
+
     # Deploy dashboard as google cloud run service
     spinner.text = "Deploying burla-main-service to Google Cloud Run ... "
     spinner.start()
@@ -446,6 +451,68 @@ def _create_service_accounts(spinner, PROJECT_ID):
         spinner.text = "Creating service accounts ... Done."
     spinner.ok("✓")
     return main_svc_email
+
+
+def _copy_node_service_image_to_user_project(spinner, PROJECT_ID):
+    """
+    `main_service/node.py` pulls node containers from
+    `us-docker.pkg.dev/{PROJECT_ID}/burla-node-service/burla-node-service:latest`.
+    `burla install` used to set up everything for main_service but leave this
+    repo empty, so pressing Start in the dashboard always 500'd with
+    "Repository 'burla-node-service' not found". Create the repo and copy
+    the canonical image from `burla-prod` (same pattern main-service uses —
+    `gcloud run deploy` pulls main-service directly from `burla-prod`).
+    """
+    spinner.text = "Copying burla-node-service image to your project ... "
+    spinner.start()
+
+    # Ensure the target repo exists. artifactregistry.googleapis.com was
+    # enabled upstream via `run.googleapis.com` dependency; calling directly
+    # is idempotent (409 if it already exists).
+    cmd = (
+        f"gcloud artifacts repositories create burla-node-service "
+        f"--project={PROJECT_ID} "
+        f"--repository-format=docker "
+        f"--location=us "
+        f'--description="Burla node service images"'
+    )
+    result = run_command(cmd, raise_error=False)
+    already_exists = result.returncode != 0 and "ALREADY_EXISTS" in result.stderr.decode()
+    if result.returncode != 0 and not already_exists:
+        spinner.fail("✗")
+        raise VerboseCalledProcessError(cmd, result.stderr)
+
+    src = f"us-docker.pkg.dev/burla-prod/burla-node-service/burla-node-service:{__version__}"
+    dst_versioned = (
+        f"us-docker.pkg.dev/{PROJECT_ID}/burla-node-service/burla-node-service:{__version__}"
+    )
+    dst_latest = f"us-docker.pkg.dev/{PROJECT_ID}/burla-node-service/burla-node-service:latest"
+
+    # `gcloud artifacts docker images copy` does the cross-project pull+push
+    # server-side without requiring a local docker daemon. `--overwrite` makes
+    # the command idempotent when re-running `burla install`.
+    copy_versioned_cmd = (
+        f"gcloud artifacts docker images copy {src} {dst_versioned} --overwrite --quiet"
+    )
+    result = run_command(copy_versioned_cmd, raise_error=False)
+    if result.returncode != 0:
+        spinner.fail("✗")
+        raise VerboseCalledProcessError(copy_versioned_cmd, result.stderr)
+
+    # Also tag as `:latest` — that's what main_service/node.py pulls by default.
+    copy_latest_cmd = (
+        f"gcloud artifacts docker images copy {src} {dst_latest} --overwrite --quiet"
+    )
+    result = run_command(copy_latest_cmd, raise_error=False)
+    if result.returncode != 0:
+        spinner.fail("✗")
+        raise VerboseCalledProcessError(copy_latest_cmd, result.stderr)
+
+    if already_exists:
+        spinner.text = "Copying burla-node-service image to your project ... Updated."
+    else:
+        spinner.text = "Copying burla-node-service image to your project ... Done."
+    spinner.ok("✓")
 
 
 def _create_firestore_database(spinner, PROJECT_ID):


### PR DESCRIPTION
## What

`burla install` set up the user's `burla-main-service` AR repo and deployed main_service to Cloud Run, but never populated the `burla-node-service` repo. `main_service/src/main_service/node.py` reads `us-docker.pkg.dev/{PROJECT_ID}/burla-node-service/burla-node-service:latest` when local-dev-mode boots a node container — on a fresh install that image didn't exist.

## UX impact

Day-one onboarding is broken. After following the documented quickstart (`pip install burla && burla install`), the user opens the dashboard, presses **Start**, and every node boot fails with an opaque `500 Internal Server Error` (actually `Repository 'burla-node-service' not found` behind the scenes). No way for a new user to recover without diving into gcloud internals. This happens on every fresh GCP project; I hit it directly while setting up each dev VM during PR #179 test work.

## Fix

Add `_copy_node_service_image_to_user_project(spinner, PROJECT_ID)` to the install flow, called right after cluster registration and before main_service deploys. It:

1. Creates the `burla-node-service` Docker AR repo in the user's project at `us-central1` (idempotent; ignores `ALREADY_EXISTS`).
2. Runs `gcloud artifacts docker images copy` from `us-docker.pkg.dev/burla-prod/burla-node-service/burla-node-service:{version}` into the user's project — twice, once tagged `:{version}`, once `:latest` (the default tag `node.py` pulls). `--overwrite` makes the step idempotent on re-runs.

Cross-project copy runs server-side via gcloud, so no local Docker daemon is required. Mirrors the existing pattern where `gcloud run deploy` pulls `burla-main-service` directly from `burla-prod`.

Single file [client/src/burla/_install.py](client/src/burla/_install.py), 67 added lines.

## Caveat

This assumes `burla-prod/burla-node-service/burla-node-service:{version}` is readable by the installer's gcloud account — same access model main-service already relies on for its Cloud Run deploy. If the node-service repo doesn't grant the equivalent read access, the fix needs both a repo-ACL change in `burla-prod` and this install-side code. Worth verifying on the `burla-prod` side before merging.