### PR TITLE
fix(client): harden Windows logging and failure diagnostics

### DIFF
--- a/client/src/burla/_heartbeat.py
+++ b/client/src/burla/_heartbeat.py
@@ -1,6 +1,7 @@
 import asyncio
 import subprocess
 import sys
+import tempfile
 import textwrap
 from asyncio import create_task
 from time import time
@@ -22,7 +23,9 @@ async def run_in_subprocess(func, *args):
         """
     )
     cmd = [sys.executable, "-u", "-c", code]
-    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    stderr_buffer = tempfile.TemporaryFile()
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=stderr_buffer)
+    process.stderr_buffer = stderr_buffer
     process.stdin.write(cloudpickle.dumps((func, args)))
     process.stdin.close()
     return process

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -20,6 +20,7 @@ from burla._reporting import RemoteParallelMapReporter, safe_print, safe_spinner
 
 
 NODE_SILENCE_TIMEOUT_SECONDS = 2 * 60
+RESULT_POLL_SILENCE_TIMEOUT_SECONDS = 10 * 60
 NODE_BOOT_DEADLINE_SEC = 10 * 60
 LOGIN_TIMEOUT_SEC = 10
 MAX_INPUT_SIZE_BYTES = 1_000_000 * 200  # 200MB
@@ -239,8 +240,15 @@ class Node:
     def _node_silence_timeout_exceeded(self):
         return self._seconds_since_last_reply() > NODE_SILENCE_TIMEOUT_SECONDS
 
+    def _result_poll_silence_timeout_exceeded(self):
+        return self._seconds_since_last_reply() > RESULT_POLL_SILENCE_TIMEOUT_SECONDS
+
     def _node_silence_timeout_message(self, action: str):
-        return f"Node {self.instance_name} has not replied for over 2 minutes while {action}.\n"
+        if action == "returning results":
+            timeout_minutes = RESULT_POLL_SILENCE_TIMEOUT_SECONDS // 60
+        else:
+            timeout_minutes = NODE_SILENCE_TIMEOUT_SECONDS // 60
+        return f"Node {self.instance_name} has not replied for over {timeout_minutes} minutes while {action}.\n"
 
     def _diagnostic_summary(self) -> str:
         line = f"Node diagnostics: id={self.instance_name}, state={self.state}"
@@ -451,7 +459,7 @@ class Node:
                     msg = f"Node {self.instance_name} disconnected while transmitting results.\n"
                     raise NodeDisconnected(self, await self._failure_message(msg))
         except NETWORK_ERROR_TYPES:
-            if self._node_silence_timeout_exceeded():
+            if self._result_poll_silence_timeout_exceeded():
                 msg = self._node_silence_timeout_message("returning results")
                 raise NodeDisconnected(self, await self._failure_message(msg))
             return self._empty_node_results()

--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -16,7 +16,7 @@ from yaspin import Spinner
 from burla import get_cluster_dashboard_url
 from burla._auth import get_auth_headers
 from burla._cluster_client import ClusterClient, _local_host_from
-from burla._reporting import RemoteParallelMapReporter
+from burla._reporting import RemoteParallelMapReporter, safe_print, safe_spinner_write
 
 
 NODE_SILENCE_TIMEOUT_SECONDS = 2 * 60
@@ -225,10 +225,13 @@ class Node:
         self.installing_packages = False
         self.result_count = 0
         self.last_reply_timestamp = time()
+        self.last_result_poll_timestamp = None
         self.started_booting_at = time()
         self.auth_headers = get_auth_headers()
         self.removed_reason = ""
-        self.spinner_compatible_print = lambda msg: spinner.write(msg) if spinner else print(msg)
+        self.spinner_compatible_print = (
+            lambda msg: safe_spinner_write(spinner, msg) if spinner else safe_print(msg)
+        )
 
     def _seconds_since_last_reply(self):
         return time() - self.last_reply_timestamp
@@ -238,6 +241,17 @@ class Node:
 
     def _node_silence_timeout_message(self, action: str):
         return f"Node {self.instance_name} has not replied for over 2 minutes while {action}.\n"
+
+    def _diagnostic_summary(self) -> str:
+        line = f"Node diagnostics: id={self.instance_name}, state={self.state}"
+        line += f", result_count={self.result_count}, current_parallelism={self.current_parallelism}"
+        line += f", seconds_since_last_reply={self._seconds_since_last_reply():.1f}"
+        if self.host:
+            line += f", host={self.host}"
+        if self.last_result_poll_timestamp is not None:
+            age = time() - self.last_result_poll_timestamp
+            line += f", seconds_since_last_result_poll={age:.1f}"
+        return line
 
     async def _failure_message(self, base_msg: str | None = None) -> str:
         base = base_msg or f"Node {self.instance_name} failed during job."
@@ -403,6 +417,7 @@ class Node:
 
     async def _gather_results(self):
         url = f"{self.host}/jobs/{self.job_id}/results"
+        self.last_result_poll_timestamp = time()
 
         async def request_function():
             return await self.session.get(

--- a/client/src/burla/_remote_parallel_map.py
+++ b/client/src/burla/_remote_parallel_map.py
@@ -42,7 +42,11 @@ from burla._node import (
     VersionMismatch,
     wait_for_nodes_to_be_ready,
 )
-from burla._reporting import RemoteParallelMapReporter, log_job_failure_telemetry
+from burla._reporting import (
+    RemoteParallelMapReporter,
+    log_job_failure_telemetry,
+    stdio_supports_unicode,
+)
 
 
 # `metadata.packages_distributions()` takes hundreds of ms to multiple seconds in
@@ -55,6 +59,50 @@ def _pkg_module_mapping():
 
 
 BANNED_PACKAGES = ["ipython", "burla", "google-colab"]
+
+
+def _read_process_stderr(process) -> str:
+    stderr_buffer = getattr(process, "stderr_buffer", None)
+    if stderr_buffer is not None:
+        stderr_buffer.flush()
+        stderr_buffer.seek(0)
+        return stderr_buffer.read().decode("utf-8", errors="replace")
+    if process.stderr is None:
+        return ""
+    return process.stderr.read().decode("utf-8", errors="replace")
+
+
+async def _job_lifecycle_exception(client: ClusterClient, job_id: str):
+    last_error = None
+    for _ in range(3):
+        try:
+            job_dict = await client.get_job(job_id) or {}
+        except Exception as error:
+            last_error = error
+            await asyncio.sleep(1)
+            continue
+        if job_dict.get("cluster_shutdown"):
+            return ClusterShutdown(), None, job_dict
+        if job_dict.get("cluster_restarted"):
+            return ClusterRestarted(), None, job_dict
+        if job_dict.get("dashboard_canceled"):
+            return JobCanceled("\n\nJob canceled from dashboard.\n"), None, job_dict
+        return None, None, job_dict
+    return None, last_error, None
+
+
+def _job_diagnostic_summary(job_dict: dict | None) -> str | None:
+    if job_dict is None:
+        return None
+    heartbeat_at = job_dict.get("client_heartbeat_at")
+    status = job_dict.get("status")
+    all_inputs_uploaded = job_dict.get("all_inputs_uploaded")
+    client_has_all_results = job_dict.get("client_has_all_results")
+    return (
+        f"Job diagnostics: status={status}, client_heartbeat_at={heartbeat_at}, "
+        f"all_inputs_uploaded={all_inputs_uploaded}, client_has_all_results={client_has_all_results}"
+    )
+
 
 class FunctionTooBig(Exception):
     def __init__(self, function_name: str):
@@ -235,6 +283,9 @@ async def _execute_job(
         def _cleanup_ping_process():
             if ping_process is not None:
                 ping_process.kill()
+                stderr_buffer = getattr(ping_process, "stderr_buffer", None)
+                if stderr_buffer is not None:
+                    stderr_buffer.close()
 
         session_stack.callback(_cleanup_ping_process)
         last_status_message_update_time = 0.0
@@ -250,16 +301,18 @@ async def _execute_job(
                 if node.state == "FAILED":
                     exception = NodeDisconnected(node, await node._failure_message())
                 if exception:
-                    # Authoritative check via main_service: if main_service has
-                    # already written a lifecycle signal on the job doc, raise
-                    # that instead of the bare infrastructure exception.
-                    job_dict = await client.get_job(job_id) or {}
-                    if job_dict.get("cluster_shutdown"):
-                        raise ClusterShutdown()
-                    if job_dict.get("cluster_restarted"):
-                        raise ClusterRestarted()
-                    if job_dict.get("dashboard_canceled"):
-                        raise JobCanceled("\n\nJob canceled from dashboard.\n")
+                    exception.add_note(node._diagnostic_summary())
+                    lifecycle_exception, lifecycle_error, job_dict = await _job_lifecycle_exception(
+                        client, job_id
+                    )
+                    if lifecycle_exception is not None:
+                        raise lifecycle_exception
+                    job_note = _job_diagnostic_summary(job_dict)
+                    if job_note is not None:
+                        exception.add_note(job_note)
+                    if lifecycle_error is not None:
+                        note = f"Also failed to read job lifecycle state: {lifecycle_error!r}"
+                        exception.add_note(note)
                     raise exception
 
             current_time = time()
@@ -293,7 +346,7 @@ async def _execute_job(
                 pinged_hosts = current_hosts
 
             if ping_process and ping_process.poll():
-                stderr = ping_process.stderr.read().decode("utf-8")
+                stderr = _read_process_stderr(ping_process)
                 raise Exception(f"Heartbeat process failed!\n{stderr}")
 
             total_result_count = sum(node.result_count for node in nodes)
@@ -487,6 +540,8 @@ def remote_parallel_map(
     return_queue = Queue()
     original_signal_handlers = None
     try:
+        if spinner is True and not stdio_supports_unicode():
+            spinner = False
         if spinner:
             spinner = yaspin(sigmap={})  # <- .start will overwrite my handlers without sigmap={}
             spinner.start()
@@ -549,7 +604,7 @@ def remote_parallel_map(
 
         if spinner:
             spinner.text = f"Done! {len(inputs)} `{function_.__name__}` calls completed."
-            spinner.ok("✔")
+            spinner.ok("OK")
 
         return _output_generator() if generator else list(_output_generator())
 

--- a/client/src/burla/_reporting.py
+++ b/client/src/burla/_reporting.py
@@ -1,9 +1,30 @@
 import os
 import json
+import sys
 
 import requests
 
 from burla import CONFIG_PATH, _BURLA_BACKEND_URL
+
+
+def _safe_for_stream(message: str, stream) -> str:
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    return message.encode(encoding, errors="replace").decode(encoding, errors="replace")
+
+
+def safe_print(message: str):
+    print(_safe_for_stream(message, sys.stdout))
+
+
+def safe_spinner_write(spinner, message: str):
+    stream = getattr(spinner, "_stream", sys.stdout)
+    spinner.write(_safe_for_stream(message, stream))
+
+
+def stdio_supports_unicode() -> bool:
+    stdout_encoding = (getattr(sys.stdout, "encoding", None) or "").lower()
+    stderr_encoding = (getattr(sys.stderr, "encoding", None) or "").lower()
+    return "utf" in stdout_encoding and "utf" in stderr_encoding
 
 
 def _get_project_id():
@@ -71,11 +92,12 @@ class RemoteParallelMapReporter:
         self.session = kwargs["session"]
         self.project_id = _get_project_id()
         self.spinner_enabled = bool(self.spinner)
+
     def _write_message(self, message: str):
         if self.spinner:
-            self.spinner.write(message)
+            safe_spinner_write(self.spinner, message)
         else:
-            print(message)
+            safe_print(message)
 
     def print_detach_mode_enabled_message(self):
         message = f"Calling `{self.function_name}` on {self.input_count} inputs with detach mode enabled!\n"
@@ -165,7 +187,7 @@ class RemoteParallelMapReporter:
         if not self.spinner:
             return
         self.spinner.text = f"Done! {self.input_count} `{self.function_name}` calls completed."
-        self.spinner.ok("✔")
+        self.spinner.ok("OK")
 
     def get_background_cancel_before_upload_message(self) -> str:
         message = "\n\nBackground job canceled before all inputs finished uploading to the cluster!"

--- a/node_service/src/node_service/job_endpoints.py
+++ b/node_service/src/node_service/job_endpoints.py
@@ -21,8 +21,42 @@ from node_service.helpers import Logger
 from node_service.job_watcher import job_watcher_logged
 
 _LOGS_OVERFLOW_MESSAGE = "Logs dequeued due to high volume, see dashboard to view all logs."
+MAX_LOGS_RESPONSE_BYTES = 1_000_000
+MAX_LOG_DOCUMENTS_PER_RESULTS_RESPONSE = 500
 
 router = APIRouter()
+
+
+def _log_document_size(log_document: dict) -> int:
+    size = 180
+    for log in log_document.get("logs", []):
+        size += len(log["message"].encode("utf-8")) + 180
+    return size
+
+
+def _pop_pending_logs() -> list:
+    at_capacity = len(SELF["pending_logs"]) == SELF["pending_logs"].maxlen
+    drained_logs = []
+    total_bytes = 0
+
+    if at_capacity:
+        now = datetime.now(timezone.utc)
+        warning_document = {
+            "logs": [{"timestamp": now, "message": _LOGS_OVERFLOW_MESSAGE}],
+            "timestamp": now,
+        }
+        drained_logs.append(warning_document)
+        total_bytes += _log_document_size(warning_document)
+
+    while SELF["pending_logs"] and len(drained_logs) < MAX_LOG_DOCUMENTS_PER_RESULTS_RESPONSE:
+        log_document = SELF["pending_logs"][0]
+        document_size = _log_document_size(log_document)
+        if drained_logs and total_bytes + document_size > MAX_LOGS_RESPONSE_BYTES:
+            break
+        drained_logs.append(SELF["pending_logs"].popleft())
+        total_bytes += document_size
+
+    return drained_logs
 
 
 @router.get("/jobs/{job_id}/get_inputs")
@@ -108,18 +142,7 @@ async def get_results(job_id: str = Path(...)):
         except asyncio.QueueEmpty:
             break
 
-    at_capacity = len(SELF["pending_logs"]) == SELF["pending_logs"].maxlen
-    drained_logs = list(SELF["pending_logs"])
-    SELF["pending_logs"].clear()
-    if at_capacity:
-        now = datetime.now(timezone.utc)
-        drained_logs.insert(
-            0,
-            {
-                "logs": [{"timestamp": now, "message": _LOGS_OVERFLOW_MESSAGE}],
-                "timestamp": now,
-            },
-        )
+    drained_logs = _pop_pending_logs()
 
     response_json = {
         "results": results,


### PR DESCRIPTION
## Summary
- Make worker log printing safe on non-UTF-8 Windows consoles so emoji output cannot crash the client.
- Preserve the original node failure when the follow-up job lifecycle lookup times out, and attach node/job diagnostics to the exception.
- Move heartbeat subprocess stderr to a temp file so repeated heartbeat warnings cannot fill a pipe and stall the subprocess.
- Let foreground result polling tolerate longer transient node timeouts and cap live log payloads from `/results` while leaving unsent logs queued for later polls.

## Test plan
- Not run, per request.