### PR TITLE
Clarify worker function load failures

### DIFF
--- a/client/src/burla/_node.py
+++ b/client/src/burla/_node.py
@@ -95,6 +95,10 @@ class NodeDisconnected(Exception):
         super().__init__(message or f"Node {node.instance_name} failed during job.")
 
 
+class FunctionLoadError(Exception):
+    pass
+
+
 class VersionMismatch(Exception):
     def __init__(self, lower_version: str, upper_version: str, current_version: str):
         msg = f"Incompatible cluster and client versions!\n"
@@ -411,6 +415,11 @@ class Node:
                     msg = f"Node {self.instance_name} is shutting down, removed from job."
                     self.spinner_compatible_print(msg)
                     return
+                elif response.status == 422:
+                    error = await response.json()
+                    if error.get("error") == "function_load_failed":
+                        raise FunctionLoadError(error["message"])
+                    raise Exception(error.get("message", "Node rejected job assignment."))
                 else:
                     msg = f"Failed to assign {self.instance_name}: {response.status}"
                     raise Exception(msg)

--- a/client/tests/test_rpm_exceptions.py
+++ b/client/tests/test_rpm_exceptions.py
@@ -87,6 +87,62 @@ def test_NodeDisconnected_carries_node_attr():
     assert "boom" in str(exc)
 
 
+@pytest.mark.unit
+def test_assign_job_surfaces_function_load_error(monkeypatch):
+    import asyncio
+    from threading import Event
+    from unittest.mock import MagicMock
+
+    from burla import _node
+    from burla._node import FunctionLoadError, Node
+
+    monkeypatch.setattr(_node, "get_auth_headers", lambda: {"Authorization": "Bearer token"})
+
+    class FakeResponse:
+        status = 422
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def json(self):
+            return {
+                "error": "function_load_failed",
+                "message": "Function failed to load inside the worker.",
+            }
+
+    class FakeSession:
+        def post(self, *args, **kwargs):
+            return FakeResponse()
+
+    node = Node.from_ready(
+        instance_name="burla-node-abc12345",
+        host="http://localhost:9999",
+        machine_type="n4-standard-2",
+        target_parallelism=1,
+        session=FakeSession(),
+        client=MagicMock(_url="http://localhost:5001"),
+        spinner=False,
+    )
+
+    async def run():
+        await node._assign_job(
+            job_id="test-job",
+            background=False,
+            n_inputs=1,
+            packages={},
+            start_time=0,
+            function_pkl=b"not-used",
+            udf_error_event=Event(),
+            assigned_node_ids=["burla-node-abc12345"],
+        )
+
+    with pytest.raises(FunctionLoadError, match="Function failed to load"):
+        asyncio.run(run())
+
+
 # ------------------------------------------------------------ AuthException (unit)
 
 

--- a/node_service/src/node_service/job_endpoints.py
+++ b/node_service/src/node_service/job_endpoints.py
@@ -1,11 +1,13 @@
 import json
 import pickle
+import traceback
 from datetime import datetime, timezone
 from typing import Optional
 
 import asyncio
 from google.cloud.firestore_v1.async_client import AsyncClient
 from fastapi import APIRouter, Path, Query, Depends, Response, Request
+from fastapi.responses import JSONResponse
 
 from node_service import (
     SELF,
@@ -57,6 +59,31 @@ def _pop_pending_logs() -> list:
         total_bytes += document_size
 
     return drained_logs
+
+
+async def _rollback_failed_assignment(workers_to_assign: list):
+    await SELF["on_job_start_task"]
+    await asyncio.gather(*(w.reset() for w in workers_to_assign))
+
+    SELF["RUNNING"] = False
+    SELF["current_job"] = None
+    async_db = AsyncClient(project=PROJECT_ID, database="burla")
+    node_doc = async_db.collection("nodes").document(INSTANCE_NAME)
+    await node_doc.update({"status": "READY", "current_job": None})
+
+
+def _function_load_failed_response(error: Exception):
+    traceback_str = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    message = (
+        "Function failed to load inside the worker before any inputs ran.\n"
+        "This usually means the function, one of its globals, or an object captured "
+        "in its closure cannot be deserialized in the worker environment.\n\n"
+        f"{traceback_str}"
+    )
+    return JSONResponse(
+        {"error": "function_load_failed", "message": message},
+        status_code=422,
+    )
 
 
 @router.get("/jobs/{job_id}/get_inputs")
@@ -244,7 +271,14 @@ async def execute(
         await workers_to_assign[0].install_packages(packages)
 
     function_pkl = request_files["function_pkl"]
-    await asyncio.gather(*(w.load_function(function_pkl) for w in workers_to_assign))
+    load_results = await asyncio.gather(
+        *(w.load_function(function_pkl) for w in workers_to_assign),
+        return_exceptions=True,
+    )
+    load_errors = [r for r in load_results if isinstance(r, Exception)]
+    if load_errors:
+        await _rollback_failed_assignment(workers_to_assign)
+        return _function_load_failed_response(load_errors[0])
 
     SELF["workers"] = workers_to_assign
     SELF["idle_workers"] = workers_to_leave_idle


### PR DESCRIPTION
## Problem

When a worker failed while deserializing `function_pkl`, node assignment raised a node-service 500. The client then reported only `Failed to assign <node>: 500`, hiding the real cause, such as `mpq.__new__() missing 1 required positional argument: 'p'` during `cloudpickle.loads()`.

## Solution

- Catch worker `load_function()` errors during node assignment.
- Roll the node back to READY and reset workers before returning.
- Return a structured `422 function_load_failed` response containing the original traceback.
- Teach the client to surface that message as `FunctionLoadError` instead of a generic assignment failure.

## How This Fixes It

The failure is now treated as a user-function load/deserialization problem before any inputs run, not as node infrastructure failure. Users get the actionable traceback from the worker, and the node is left ready for later jobs instead of rebooting from middleware 500 handling.

## Test plan

- `uv run --project client pytest client/tests/test_rpm_exceptions.py -m unit`
- `uv run --project node_service python -m py_compile node_service/src/node_service/job_endpoints.py`