### PR TITLE
Investigate ADC auth retry unauthorized errors

### DIFF
--- a/client/src/burla/_cluster_client.py
+++ b/client/src/burla/_cluster_client.py
@@ -18,6 +18,10 @@ from burla._auth import bootstrap_from_adc, get_auth_headers
 _TIMEOUT = aiohttp.ClientTimeout(total=30)
 
 
+def _is_login_response(response) -> bool:
+    return response.status in (200, 401) and response.content_type == "text/html"
+
+
 class NodesBusy(Exception):
     """
     Raised by `ClusterClient.start_job` on a 503 nodes_busy response - no
@@ -79,7 +83,7 @@ class ClusterClient:
         ) as response:
             if response.status == 404:
                 return None
-            if (response.status == 401 or response.content_type == "text/html") and retry_adc_bootstrap:
+            if (response.status == 401 or _is_login_response(response)) and retry_adc_bootstrap:
                 bootstrap_from_adc()
                 self._url = get_cluster_dashboard_url()
                 return await self._request(
@@ -137,7 +141,7 @@ class ClusterClient:
                     body = (await response.json()) or {}
                 except aiohttp.ContentTypeError:
                     body = {}
-                auth_failed = response.status == 401 or response.content_type == "text/html"
+                auth_failed = response.status == 401 or _is_login_response(response)
             if auth_failed and attempt == 0:
                 bootstrap_from_adc()
                 self._url = get_cluster_dashboard_url()


### PR DESCRIPTION
## Summary
- Fixes the client-side auth heuristic that treated any HTML response from `main_service` as an auth/login response.
- Adds focused tests proving real login HTML still triggers one ADC bootstrap retry, while server-error HTML no longer gets mislabeled as `UnauthorizedError`.
- Removes a stale unit test that expected missing client credentials to raise instead of bootstrapping from ADC.

## Problem
In environments with Google Application Default Credentials, Burla 1.5.10 is expected to recover from stale or missing client auth by reading the cluster token from Secret Manager, exchanging it with the backend service for user auth tied to the ADC email, writing refreshed client credentials, and retrying the job request.

## Expected behavior
When `/v1/jobs/{job_id}/start` hits stale auth, the client should bootstrap from ADC and retry. If the retry reaches a real server-side error or version mismatch, the client should surface that real response instead of saying the user is unauthorized.

## Actual behavior
The notebook job failed with `UnauthorizedError: Unauthorized! Please run \`burla login\` to authenticate.` The same failure reproduced with a one-input RPM. Investigation showed the real `/v1/jobs/{job_id}/start` response was `500 text/html Internal server error` when the request body included `func_ram="dynamic"`. The client classified all `text/html` responses as auth failures, so it retried ADC bootstrap and ultimately collapsed the server 500 into the generic unauthorized message.

## Root Cause
The deployed `test.burla.dev` main_service is still version `1.5.9`:

```text
GET /version -> {"version":"1.5.9","project":"burla-test"}
GET /v1/settings -> "burlaVersion":"1.5.9"
```

PR #199 did add server-side support for `func_ram="dynamic"` on `main`, but it was not deployed to `test.burla.dev`. In pre-PR199 server code, `/v1/jobs/{job_id}/start` does:

```python
func_ram = int(body["func_ram"])
```

So a 1.5.10 client sends the new default `func_ram="dynamic"`, the 1.5.9 server raises `ValueError`, and FastAPI returns `500 text/html Internal server error`. Numeric RAM still reaches the version gate correctly:

```text
func_ram="dynamic" -> 500 text/html Internal server error
func_ram=1         -> 409 version_mismatch, supports 1.5.9 - 1.5.9
```

The auth/ADC exchange path itself was not the root failure in this repro: `/v1/cluster/state` validates successfully before and after `bootstrap_from_adc()` for the same credentials.

## Fix In This PR
The client no longer treats arbitrary HTML responses as auth failures. It only treats `200/401 text/html` as login/auth HTML. That preserves ADC retry behavior for real login pages while surfacing server 500s as server errors.

The server-side dynamic RAM acceptance already exists on `main` from PR #199; `test.burla.dev` needs to run a version containing that PR, or clients should not default to `func_ram="dynamic"` against older clusters.

## Test plan
- [x] `uv run pytest tests/test_adc_live_integration.py::test_start_job_retries_adc_bootstrap_once_on_login_response tests/test_adc_live_integration.py::test_start_job_does_not_treat_server_error_html_as_auth_failure tests/test_rpm_exceptions.py::test_VersionMismatch_pip_install_hint -q`
- [x] Live repro before fix: one-input `remote_parallel_map(..., func_ram="dynamic")` raised generic `UnauthorizedError`.
- [x] Live repro after fix: same call raises `POST /v1/jobs/.../start failed: 500 {}`.
- [x] Live hypothesis check: `func_ram=1` returns `VersionMismatch`; `func_ram="dynamic"` returns server 500 because deployed server is 1.5.9.
- [ ] Deploy or run matching 1.5.10 main_service and verify dynamic RAM job start succeeds or returns the intended domain error.