### PR TITLE
Pre-populate worker python env on host VM

### DIFF
--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -519,6 +519,19 @@ class Node:
 
         uv venv --python 3.13 --seed
         uv pip install ./node_service
+
+        # Pre-populate the shared worker python env so worker[0]'s boot doesn't have
+        # to download uv from GitHub and `uv pip install burla` over PyPI inside the
+        # container. Worker_server.py short-circuits both steps when uv is on PATH and
+        # `importlib.metadata.version("burla") == target_burla_version`. CURRENT_BURLA_VERSION
+        # is templated into this script so this stays in sync with each release.
+        mkdir -p /worker_service_python_env/bin
+        cp "$(command -v uv)" /worker_service_python_env/bin/uv
+        uv pip install \
+            --python-version 3.12 \
+            --python-platform x86_64-manylinux2014 \
+            --target /worker_service_python_env \
+            burla=={CURRENT_BURLA_VERSION}
         
         total_memory_kb=$(awk '/MemTotal/ {{print $2}}' /proc/meminfo)
         worker_memory_kb=$((total_memory_kb - {NODE_SERVICE_RESERVED_MEMORY_GB} * 1024 * 1024))

--- a/main_service/src/main_service/node.py
+++ b/main_service/src/main_service/node.py
@@ -520,18 +520,29 @@ class Node:
         uv venv --python 3.13 --seed
         uv pip install ./node_service
 
-        # Pre-populate the shared worker python env so worker[0]'s boot doesn't have
-        # to download uv from GitHub and `uv pip install burla` over PyPI inside the
-        # container. Worker_server.py short-circuits both steps when uv is on PATH and
-        # `importlib.metadata.version("burla") == target_burla_version`. CURRENT_BURLA_VERSION
-        # is templated into this script so this stays in sync with each release.
-        mkdir -p /worker_service_python_env/bin
-        cp "$(command -v uv)" /worker_service_python_env/bin/uv
-        uv pip install \
-            --python-version 3.12 \
-            --python-platform x86_64-manylinux2014 \
-            --target /worker_service_python_env \
-            burla=={CURRENT_BURLA_VERSION}
+        # Pre-populate the shared /worker_service_python_env so worker[0]'s boot doesn't
+        # have to download uv from GitHub and `uv pip install burla` over PyPI inside the
+        # container. We detect the python version from the first user container image
+        # because cp311/cp312/cp313 C-extension wheels (cryptography, aiohttp, …) are
+        # ABI-incompatible across cpython tags. Subshell makes the whole block best-effort:
+        # if the image is missing python or anything else trips, fall through and let
+        # worker_server.py run its own download path rather than killing the VM via the
+        # outer trap.
+        (
+            FIRST_IMAGE=$(echo "$CONTAINERS" | python3 -c \
+                'import json,sys; d=json.load(sys.stdin); print(d[0]["image"] if d else "")')
+            [ -n "$FIRST_IMAGE" ] || exit 0
+            docker pull "$FIRST_IMAGE" >/dev/null
+            PY_VERSION=$(docker run --rm --entrypoint python "$FIRST_IMAGE" -c \
+                'import sys; print(f"{{sys.version_info.major}}.{{sys.version_info.minor}}")')
+            mkdir -p /worker_service_python_env/bin
+            cp "$(command -v uv)" /worker_service_python_env/bin/uv
+            uv pip install \
+                --python-version "$PY_VERSION" \
+                --python-platform x86_64-manylinux2014 \
+                --target /worker_service_python_env \
+                "burla=={CURRENT_BURLA_VERSION}"
+        ) || true
         
         total_memory_kb=$(awk '/MemTotal/ {{print $2}}' /proc/meminfo)
         worker_memory_kb=$((total_memory_kb - {NODE_SERVICE_RESERVED_MEMORY_GB} * 1024 * 1024))

--- a/node_service/src/node_service/worker_client.py
+++ b/node_service/src/node_service/worker_client.py
@@ -33,11 +33,10 @@ LOG_START_MARKER_PREFIX = "__burla_input_start__:"
 LOG_END_MARKER_PREFIX = "__burla_input_end__:"
 OOM_KILL_MARKER_PREFIX = "__burla_oom_kill__:"
 
-# Workers normally boot in <2s because main_service's startup script pre-populates the shared
-# /worker_service_python_env with uv + burla deps. This budget exists for fallback paths (env
-# missing/corrupt, container restart racing a partial install) where worker_server.py would
-# fall back to downloading uv from GitHub and `uv pip install burla` from PyPI.
-WORKER_BOOT_TIMEOUT_SECONDS = 60
+# The first worker on a fresh VM downloads uv from GitHub and installs cloudpickle/tblib into
+# /worker_service_python_env before opening its socket. Under any network slowness this can take
+# well over 10 seconds; 10s was causing ~15% of initial boots to fail.
+WORKER_BOOT_TIMEOUT_SECONDS = 20
 DYNAMIC_RAM_MAX_NODE_MEMORY_USED_FRACTION = 0.90
 DYNAMIC_RAM_TARGET_NODE_MEMORY_USED_FRACTION = 0.85
 DYNAMIC_RAM_MONITOR_INTERVAL_SECONDS = 0.25

--- a/node_service/src/node_service/worker_client.py
+++ b/node_service/src/node_service/worker_client.py
@@ -33,10 +33,11 @@ LOG_START_MARKER_PREFIX = "__burla_input_start__:"
 LOG_END_MARKER_PREFIX = "__burla_input_end__:"
 OOM_KILL_MARKER_PREFIX = "__burla_oom_kill__:"
 
-# The first worker on a fresh VM downloads uv from GitHub and installs cloudpickle/tblib into
-# /worker_service_python_env before opening its socket. Under any network slowness this can take
-# well over 10 seconds; 10s was causing ~15% of initial boots to fail.
-WORKER_BOOT_TIMEOUT_SECONDS = 20
+# Workers normally boot in <2s because main_service's startup script pre-populates the shared
+# /worker_service_python_env with uv + burla deps. This budget exists for fallback paths (env
+# missing/corrupt, container restart racing a partial install) where worker_server.py would
+# fall back to downloading uv from GitHub and `uv pip install burla` from PyPI.
+WORKER_BOOT_TIMEOUT_SECONDS = 60
 DYNAMIC_RAM_MAX_NODE_MEMORY_USED_FRACTION = 0.90
 DYNAMIC_RAM_TARGET_NODE_MEMORY_USED_FRACTION = 0.85
 DYNAMIC_RAM_MONITOR_INTERVAL_SECONDS = 0.25


### PR DESCRIPTION
## Summary

Move `uv` download + `uv pip install burla` out of the worker container's first-run hot path and into the host VM's startup script. Detect the user image's python version dynamically (so cp311 / cp312 / cp313 / etc. all get matching ABI wheels).

The host startup script already has `uv` installed and is templated with `CURRENT_BURLA_VERSION`. New flow:

1. Parse `CONTAINERS` (env var the startup-script already exports) and grab the first image.
2. `docker pull` it (no-op when node_service later pulls; saves time).
3. `docker run --rm --entrypoint python "$IMAGE" -c '...sys.version_info...'` to get e.g. `3.13`.
4. `uv pip install --python-version "$PY_VERSION" --python-platform x86_64-manylinux2014 --target /worker_service_python_env burla==<CURRENT_BURLA_VERSION>`.
5. `cp $(command -v uv) /worker_service_python_env/bin/uv` so worker_server.py's `shutil.which("uv")` short-circuits.

The whole block is wrapped in a subshell + `|| true`. If the image has no python on PATH, the registry isn't accessible, or anything else goes wrong, the env is just left empty and worker_server.py falls through to its existing GitHub uv download / `uv pip install burla` path on first boot. We never let pre-populate failure trigger the outer `set -Eeuo pipefail` trap and delete the VM.

Multi-image cluster configs use the first image's python version. That's the same constraint the existing per-worker install has: a single `/worker_service_python_env` is mounted into every worker regardless of image, so it has to pick one ABI tag. Not addressed in this PR.

`worker_server.py` short-circuits cleanly because it already checks both `shutil.which("uv")` and `importlib.metadata.version("burla") == target_burla_version`.

## Why

Worker[0] was consistently exceeding the 20s boot budget on fresh VMs because it had to download uv from GitHub plus install ~20 PyPI deps inside the container before opening its TCP socket. In burla-3 that produced 36 `Worker boot timed out after 20 seconds` failures on 2026-05-06 alone, every single one tracing back to `lifecycle_endpoints.py:374 await workers[0].boot()` with the buffered worker logs containing only `3.12` (the python-version line printed before the install steps).

## Test plan

- [x] Implemented in worktree, no lint errors.
- [x] Synced to dev VM slot 04 (`burla-agent-04`), ran `make -f makefile remote-dev`.
- [x] Set `cluster_config.Nodes[0].containers[0].image = "python:3.13"` (intentionally different from the previous default 3.12) and triggered `/v1/cluster/restart`.
- [x] Verified on the booted node (`burla-node-2da1c4dc`):
  - `find /worker_service_python_env -name "*cpython-313*" | wc -l` -> 15 (cp313 .so files for `frozenlist`, `propcache`, `charset_normalizer`, etc.).
  - `find /worker_service_python_env -name "*cpython-312*"` -> 0.
  - `cryptography-48.0.0.dist-info/WHEEL` -> `Tag: cp311-abi3-manylinux_2_17_x86_64` (abi3-stable, runs on 3.13).
- [x] Verified all 4 worker container logs contain only `3.13` -> worker_server.py skipped both download paths.
- [x] Boot timing on the test node: image pulled (cached from pre-populate, <1s) at 14:58:17, all 4 workers ready at 14:58:20 (~3s end-to-end vs ~9s previously).