### PR TITLE
Make AWS the persistent default cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,21 @@ This example runs `my_function` on 1,000 VMs in less than one second:
 
 ## Getting started
 
-You'll need Python 3.11+, a Google Cloud project with billing enabled, and the [gcloud CLI](https://cloud.google.com/sdk/docs/install) authenticated (`gcloud auth login` and `gcloud auth application-default login`).
+You'll need Python 3.11+ and permission to boot VMs. Burla defaults to the
+account and region selected by your AWS CLI.
 
 ```bash
 pip install burla
 ```
 
 That's the whole setup. If you can boot a VM in your cloud project, you can use Burla: no service accounts, buckets, firewall rules, or IAM changes are needed.
+
+To use GCP instead, select it once and Burla will use the active gcloud project:
+
+```bash
+burla config set cloud gcp
+gcloud config set project <project-id>
+```
 
 ```python
 from burla import remote_parallel_map
@@ -74,7 +82,10 @@ def my_function(x):
 results = remote_parallel_map(my_function, list(range(1000)))
 ```
 
-Burla runs its cluster coordinator on your machine and boots VMs in your project using your own credentials (the VMs carry no credentials at all, and shut themselves down when idle). Run `burla dashboard` to open the cluster dashboard locally, boot machines manually, watch jobs, or change machine types.
+The first `remote_parallel_map` call starts Burla's cluster coordinator on your
+machine automatically. The VMs carry no credentials and shut themselves down
+when idle. Run `burla dashboard` at any time to open that same local coordinator,
+boot machines manually, watch jobs, or change machine types.
 
 **Deploying for a team (optional):** `burla deploy` moves the coordinator and dashboard onto a small always-on VM so teammates can share one cluster. This is the only step that requires elevated permissions (service-account and IAM setup); the exact list is in the [CLI reference](https://docs.burla.dev/cli-reference). After deploying, teammates connect with `burla login`.
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -14,6 +14,42 @@ _BURLA_BACKEND_URL = os.environ.get(
 
 _appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))
 CONFIG_PATH = _appdata_dir / Path("burla_credentials.json")
+SETTINGS_PATH = _appdata_dir / Path("config.json")
+
+
+def get_cloud() -> str:
+    override = os.environ.get("BURLA_CLOUD")
+    if override:
+        return override.lower()
+    if SETTINGS_PATH.exists():
+        return json.loads(SETTINGS_PATH.read_text())["cloud"]
+    return "aws"
+
+
+def set_config(key: str, value: str) -> str:
+    if key != "cloud":
+        raise ValueError("The only supported config key is `cloud`.")
+    cloud = value.lower()
+    if cloud not in ("aws", "gcp"):
+        raise ValueError("cloud must be `aws` or `gcp`.")
+
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SETTINGS_PATH.write_text(json.dumps({"cloud": cloud}))
+
+    if CONFIG_PATH.exists():
+        credentials = json.loads(CONFIG_PATH.read_text())
+        credentials["mode"] = "client_hosted"
+        CONFIG_PATH.write_text(json.dumps(credentials))
+    return f"cloud = {cloud}"
+
+
+def get_config(key: str = None):
+    config = {"cloud": get_cloud()}
+    if key is None:
+        return config
+    if key not in config:
+        raise ValueError("The only supported config key is `cloud`.")
+    return config[key]
 
 
 def _local_dashboard_url(url: str) -> bool:
@@ -40,29 +76,9 @@ def get_cluster_dashboard_url() -> str:
         return override
 
     if not CONFIG_PATH.exists():
-        # A deployed cluster is used when one is reachable (via `burla login`
-        # or the ADC bootstrap); otherwise default to client-hosted mode.
-        from burla._auth import (
-            ADCBootstrapException,
-            ADCProjectException,
-            ADCSecretPermissionException,
-            BurlaNotInstalledException,
-            bootstrap_from_adc,
-        )
-        from google.auth.exceptions import DefaultCredentialsError
+        from burla._local_head import ensure_local_head
 
-        try:
-            bootstrap_from_adc()
-        except (
-            ADCBootstrapException,
-            ADCProjectException,
-            ADCSecretPermissionException,
-            BurlaNotInstalledException,
-            DefaultCredentialsError,
-        ):
-            from burla._local_head import ensure_local_head
-
-            return ensure_local_head()
+        return ensure_local_head()
 
     config = json.loads(CONFIG_PATH.read_text())
     if config.get("mode") == "client_hosted" or not config.get("cluster_dashboard_url"):
@@ -103,7 +119,7 @@ def version():
     print(__version__)
 
 
-def dashboard(cloud: str = None):
+def dashboard():
     """Open the Burla dashboard, hosted on this machine.
 
     Starts the cluster head locally if it isn't already running - from there
@@ -114,7 +130,7 @@ def dashboard(cloud: str = None):
 
     from burla._local_head import ensure_local_head
 
-    url = ensure_local_head(cloud=cloud)
+    url = ensure_local_head()
     print(f"Burla dashboard is running at {url}")
     webbrowser.open(url)
 
@@ -132,6 +148,10 @@ def init_cli():
             "login": login,
             "deploy": deploy,
             "dashboard": dashboard,
+            "config": {
+                "set": set_config,
+                "get": get_config,
+            },
             "install": install,
             "--version": version,
             "-v": version,

--- a/client/src/burla/_local_head.py
+++ b/client/src/burla/_local_head.py
@@ -51,12 +51,17 @@ def _state_dir(project_id: str) -> Path:
 # ------------------------------------------------------------------ cloud
 
 
-def detect_cloud(cloud: str | None = None) -> tuple[str, str, str | None]:
-    """Returns (cloud, project_id, aws_region). Prefers GCP when both CLIs
-    are configured; the argument or BURLA_CLOUD=gcp|aws overrides."""
-    forced = cloud or os.environ.get("BURLA_CLOUD", "").lower() or None
+def detect_cloud() -> tuple[str, str, str | None]:
+    """Returns (cloud, project_id, aws_region) for the configured cloud."""
+    from burla import get_cloud
 
-    if forced in (None, "gcp") and shutil.which("gcloud"):
+    cloud = get_cloud()
+    if cloud == "gcp":
+        if not shutil.which("gcloud"):
+            raise LocalHeadError(
+                "GCP is selected, but gcloud is not installed. "
+                "Install it or run `burla config set cloud aws`."
+            )
         result = subprocess.run(
             ["gcloud", "config", "get-value", "project"],
             capture_output=True,
@@ -65,31 +70,36 @@ def detect_cloud(cloud: str | None = None) -> tuple[str, str, str | None]:
         gcp_project = result.stdout.strip()
         if gcp_project and gcp_project != "(unset)":
             return "gcp", gcp_project, None
-        if forced == "gcp":
-            raise LocalHeadError(
-                "No gcloud project is set. Run `gcloud config set project <id>`."
-            )
-
-    if forced in (None, "aws") and shutil.which("aws"):
-        result = subprocess.run(
-            ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
-            capture_output=True,
-            text=True,
+        raise LocalHeadError(
+            "GCP is selected, but no gcloud project is set. "
+            "Run `gcloud config set project <id>`."
         )
-        account_id = result.stdout.strip()
-        if result.returncode == 0 and account_id:
-            region_result = subprocess.run(
-                ["aws", "configure", "get", "region"], capture_output=True, text=True
-            )
-            region = region_result.stdout.strip() or "us-east-1"
-            return "aws", f"aws-{account_id}", region
 
-    raise LocalHeadError(
-        "Could not find working cloud credentials.\n"
-        "- For Google Cloud: install gcloud, then run `gcloud auth login` "
-        "and `gcloud auth application-default login`.\n"
-        "- For AWS: install the aws CLI and run `aws configure`."
+    if not shutil.which("aws"):
+        raise LocalHeadError(
+            "AWS is selected, but the AWS CLI is not installed. "
+            "Install it or run `burla config set cloud gcp`."
+        )
+    result = subprocess.run(
+        ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
+        capture_output=True,
+        text=True,
     )
+    if result.returncode != 0:
+        raise LocalHeadError(
+            "AWS is selected, but its credentials are not active. "
+            "Run `aws configure` or `aws sso login`, then retry."
+        )
+    region_result = subprocess.run(
+        ["aws", "configure", "get", "region"], capture_output=True, text=True
+    )
+    region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or region_result.stdout.strip()
+        or "us-east-1"
+    )
+    return "aws", f"aws-{result.stdout.strip()}", region
 
 
 def _gcp_ownership_payload() -> dict:
@@ -206,7 +216,9 @@ def ensure_user_authorized(
     from burla._auth import _write_auth_config
 
     if CONFIG_PATH.exists():
-        return
+        auth_info = json.loads(CONFIG_PATH.read_text())
+        if auth_info["project_id"] == project_id:
+            return
 
     if cloud == "aws":
         result = subprocess.run(
@@ -392,9 +404,9 @@ def _prepare_aws(project_id: str, aws_region: str):
     marker.write_text("done")
 
 
-def ensure_local_head(cloud: str = None) -> str:
+def ensure_local_head() -> str:
     """Starts (or reuses) the client-hosted main_service and returns its URL."""
-    cloud, project_id, aws_region = detect_cloud(cloud)
+    cloud, project_id, aws_region = detect_cloud()
 
     state_dir = _state_dir(project_id)
     head_state_path = state_dir / "head.json"


### PR DESCRIPTION
## Summary
- default client-hosted Burla to AWS instead of auto-preferring GCP
- add persistent `burla config set|get cloud` commands shared by RPM and dashboard
- remove the dashboard cloud flag and make RPM start the local head automatically

## Test plan
- [x] `make test-unit` (54 passed)
- [x] clean CLI config defaults to AWS and persists GCP selection
- [x] dashboard signature has no cloud argument
- [x] cloud switching forces client-hosted mode and RPM auto-starts the local head
- [x] client sdist and wheel build successfully