### PR TITLE
Persist client-hosted mode when opening dashboard

### DIFF
--- a/client/src/burla/_local_head.py
+++ b/client/src/burla/_local_head.py
@@ -218,6 +218,9 @@ def ensure_user_authorized(
     if CONFIG_PATH.exists():
         auth_info = json.loads(CONFIG_PATH.read_text())
         if auth_info["project_id"] == project_id:
+            if auth_info.get("mode") != "client_hosted":
+                auth_info["mode"] = "client_hosted"
+                _write_auth_config(auth_info)
             return
 
     if cloud == "aws":


### PR DESCRIPTION
## Summary
- mark existing credentials as client-hosted when `burla dashboard` starts the local head
- ensure subsequent RPM calls reuse that local head instead of a stale deployed dashboard URL

## Test plan
- [x] existing credential metadata switches to `mode=client_hosted`
- [x] `make test-unit` (54 passed)
- [x] live `burla dashboard` opens at `http://127.0.0.1:5001` against the AWS test account