### PR TITLE
Skip dashboard login on client-hosted heads

### DIFF
--- a/client/src/burla/_local_head.py
+++ b/client/src/burla/_local_head.py
@@ -429,6 +429,10 @@ def ensure_local_head() -> str:
     if cloud == "aws":
         _prepare_aws(project_id, aws_region)
 
+    from burla import CONFIG_PATH
+
+    auth_info = json.loads(CONFIG_PATH.read_text())
+
     # Stale processes from an old version/session die before their ports are reused.
     for pid_key in ("head_pid", "frpc_pid"):
         if _pid_alive(head_state.get(pid_key)):
@@ -457,6 +461,10 @@ def ensure_local_head() -> str:
         "HISTORY_DB_PATH": str(state_dir / "history.db"),
         "BURLA_TLS_DIR": str(state_dir / "tls"),
         "REDIRECT_LOCALLY_ON_LOGIN": "True",
+        # The owner's real credentials: local dashboard/browser requests are
+        # stamped with these instead of being asked to log in.
+        "BURLA_LOCAL_USER_EMAIL": auth_info["email"],
+        "BURLA_LOCAL_USER_TOKEN": auth_info["auth_token"],
     }
     if aws_region:
         environment["AWS_REGION"] = aws_region

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -38,6 +38,13 @@ REDIRECT_LOCALLY_ON_LOGIN = os.environ.get("REDIRECT_LOCALLY_ON_LOGIN") == "True
 # accounts, no buckets - see client/src/burla/_local_head.py.
 IN_CLIENT_HOSTED_MODE = os.environ.get("IN_CLIENT_HOSTED_MODE") == "True"
 
+# The owner's real backend credentials (from burla_credentials.json). Local
+# requests to a client-hosted head are stamped with these instead of being
+# sent through the login flow - they must be real because head -> node calls
+# replay them, and nodes validate them against the backend's user list.
+LOCAL_USER_EMAIL = os.environ.get("BURLA_LOCAL_USER_EMAIL", "")
+LOCAL_USER_TOKEN = os.environ.get("BURLA_LOCAL_USER_TOKEN", "")
+
 # "gcp" or "aws" - which cloud this cluster boots node VMs in.
 CLOUD_PROVIDER = os.environ.get("CLOUD_PROVIDER", "gcp")
 
@@ -584,6 +591,40 @@ async def validate_requests(request: Request, call_next):
                 request.session["name"] = "Local Dev"
                 request.session["profile_pic"] = ""
         return await call_next(request)
+
+    # Client-hosted bypass: this head only listens on 127.0.0.1, so a local
+    # request is the machine's owner - their own dashboard needs no login.
+    # Two kinds of traffic also arrive from 127.0.0.1 and must still log in:
+    # relay-tunnel connections (they come through the in-process TLS proxy,
+    # recognized by their socket address) and cross-site browser requests
+    # (a foreign Origin header means some other webpage sent it).
+    if IN_CLIENT_HOSTED_MODE:
+        from main_service.tls_proxy import RELAY_CLIENT_ADDRESSES
+
+        client_address = (request.client.host, request.client.port)
+        origin = request.headers.get("origin")
+        origin_is_local = origin is None or urlparse(origin).hostname in (
+            "127.0.0.1",
+            "localhost",
+        )
+        is_machine_owner = (
+            request.client.host == "127.0.0.1"
+            and client_address not in RELAY_CLIENT_ADDRESSES
+            and origin_is_local
+        )
+        if is_machine_owner:
+            if not request.session.get("X-User-Email"):
+                header_email = request.headers.get("X-User-Email")
+                header_auth = request.headers.get("Authorization")
+                if header_email and header_auth:
+                    request.session["X-User-Email"] = header_email
+                    request.session["Authorization"] = header_auth
+                else:
+                    request.session["X-User-Email"] = LOCAL_USER_EMAIL
+                    request.session["Authorization"] = f"Bearer {LOCAL_USER_TOKEN}"
+                request.session["name"] = request.session["X-User-Email"]
+                request.session["profile_pic"] = ""
+            return await call_next(request)
 
     # Allow unauthenticated access for storage stub endpoints and resumable signing during development
     # These are non-privileged helpers used by the storage UI.

--- a/main_service/src/main_service/tls_proxy.py
+++ b/main_service/src/main_service/tls_proxy.py
@@ -13,6 +13,12 @@ import ssl
 
 from main_service.transport_tls import HEAD_CERT_PATH, HEAD_KEY_PATH
 
+# Loopback (host, port) addresses of this proxy's live connections to uvicorn.
+# Relay traffic and the owner's own browser both reach uvicorn from 127.0.0.1;
+# the auth middleware uses this set to tell them apart (relay traffic must
+# still log in, the owner's local traffic must not have to).
+RELAY_CLIENT_ADDRESSES: set[tuple[str, int]] = set()
+
 
 async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
     try:
@@ -40,8 +46,21 @@ async def start_tls_proxy(listen_port: int, forward_port: int):
         except OSError:
             client_writer.close()
             return
-        asyncio.create_task(_pipe(client_reader, upstream_writer))
-        asyncio.create_task(_pipe(upstream_reader, client_writer))
+
+        sockname = upstream_writer.get_extra_info("sockname")
+        proxy_address = (sockname[0], sockname[1])
+        RELAY_CLIENT_ADDRESSES.add(proxy_address)
+
+        async def pipe_both_directions():
+            try:
+                await asyncio.gather(
+                    _pipe(client_reader, upstream_writer),
+                    _pipe(upstream_reader, client_writer),
+                )
+            finally:
+                RELAY_CLIENT_ADDRESSES.discard(proxy_address)
+
+        asyncio.create_task(pipe_both_directions())
 
     return await asyncio.start_server(
         handle, host="0.0.0.0", port=listen_port, ssl=ssl_context


### PR DESCRIPTION
## Summary
- local requests to a client-hosted head no longer see the login page: sessions are stamped with the owner's real credentials (passed by the head runner), so head-to-node calls still authenticate
- the TLS proxy now tracks its connection addresses so relay-tunnel traffic, which also arrives from 127.0.0.1, still requires login
- cross-site browser requests (foreign Origin header) also still require login, blocking drive-by requests to the local port

## Test plan
- [x] local request with no auth serves the dashboard; /api/user shows the owner identity
- [x] request with a foreign Origin gets the login page
- [x] request through the TLS proxy (relay path) gets the login page
- [x] cluster-token requests unchanged
- [x] `make test-unit` (54 passed)