### PR TITLE
Show cloud identity throughout settings

### DIFF
--- a/main_service/frontend/src/pages/Settings.tsx
+++ b/main_service/frontend/src/pages/Settings.tsx
@@ -149,6 +149,12 @@ const SettingsPage = () => {
   };
 
   const showSaveButton = section === "cluster" && hasUnsavedChanges;
+  const isAws = settings.cloudProvider === "aws";
+  const cloudLabel = isAws ? "AWS" : "GCP";
+  const resourceLabel = isAws ? "Account" : "Project";
+  const resourceId = isAws
+    ? (settings.googleCloudProjectId ?? "").replace(/^aws-/, "")
+    : settings.googleCloudProjectId;
 
   const content = (() => {
     if (loading) {
@@ -201,6 +207,25 @@ const SettingsPage = () => {
           <div className="flex items-center justify-between gap-6">
             <div className="min-w-0">
               <h1 className="text-2xl font-bold text-primary">Settings</h1>
+              {!loading && !error && (
+                <div className="mt-2 flex min-w-0 items-center gap-2 text-sm">
+                  <span
+                    className={[
+                      "inline-flex shrink-0 items-center rounded-md px-2 py-0.5",
+                      "font-semibold tracking-wide",
+                      isAws
+                        ? "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200"
+                        : "bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200",
+                    ].join(" ")}
+                  >
+                    {cloudLabel}
+                  </span>
+                  <span className="shrink-0 text-gray-500">{resourceLabel}:</span>
+                  <code className="truncate font-mono text-gray-800" title={resourceId}>
+                    {resourceId}
+                  </code>
+                </div>
+              )}
             </div>
 
             <div className="min-w-[92px] flex justify-end">

--- a/main_service/src/main_service/static/index.html
+++ b/main_service/src/main_service/static/index.html
@@ -10,8 +10,8 @@
         />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="apple-touch-icon" href="/favicon.png" />
-      <script type="module" crossorigin src="/assets/index-DyQfYENv.js"></script>
-      <link rel="stylesheet" crossorigin href="/assets/index-UHQ3Z-44.css">
+      <script type="module" crossorigin src="/assets/index-CU16ajPg.js"></script>
+      <link rel="stylesheet" crossorigin href="/assets/index-BZmGhdm1.css">
     </head>
 
     <body>


### PR DESCRIPTION
## Summary
- show the current cloud provider directly below the Settings heading
- show the GCP project ID or AWS account ID, stripping Burla's internal `aws-` prefix
- keep the identity visible on both Cluster and Usage tabs

## Test plan
- [x] dashboard production build
- [x] ESLint on Settings.tsx
- [x] `make test-unit` (54 passed)
- [x] browser QA on live AWS local head: `AWS · Account: 002645521087` visible on Cluster and Usage
- [x] no browser console errors from the settings page after reload