### PR TITLE
Show AWS account name instead of account ID

### DIFF
--- a/client/src/burla/_deploy_aws.py
+++ b/client/src/burla/_deploy_aws.py
@@ -45,6 +45,7 @@ def _head_setup_commands(
     image: str,
     dashboard_hostname: str,
     cluster_id_token: str,
+    account_name: str,
 ) -> list[str]:
     node_source_ref = os.environ.get("BURLA_NODE_SOURCE_REF", __version__)
     relay_subdomain = f"head--{project_id}"
@@ -78,6 +79,7 @@ def _head_setup_commands(
             '-e CLUSTER_ID_TOKEN="$CLUSTER_ID_TOKEN" '
             "-e CLOUD_PROVIDER=aws "
             f'-e AWS_REGION="{region}" '
+            f'-e CLOUD_ACCOUNT_NAME="{account_name}" '
             "-e BIND_HOST=127.0.0.1 "
             "-e PORT=5001 "
             "-e INTERNAL_TLS_PORT=8443 "
@@ -222,6 +224,9 @@ def deploy_aws(spinner):
     )
     # Cluster id: what backend.burla.dev and the dashboard know this cluster as.
     project_id = f"aws-{account_id}"
+    from burla._local_head import _aws_account_name
+
+    account_name = _aws_account_name(account_id)
     spinner.text = f"Checking for aws CLI ... Using account {account_id} in {region}."
     spinner.ok("✓")
     log_telemetry("Installer has aws CLI and is logged in.", project_id=project_id)
@@ -233,7 +238,7 @@ def deploy_aws(spinner):
     cluster_id_token = _register_cluster_and_save_token(spinner, project_id, region)
     _ensure_node_ami(spinner, region, node_profile)
     dashboard_url = _deploy_head_instance(
-        spinner, project_id, region, head_sg_id, cluster_id_token
+        spinner, project_id, region, head_sg_id, cluster_id_token, account_name
     )
 
     headers = {"Authorization": f"Bearer {cluster_id_token}"}
@@ -656,7 +661,9 @@ def _run_head_update(region: str, instance_id: str, commands: list[str]):
         raise Exception(invocation["StandardErrorContent"])
 
 
-def _deploy_head_instance(spinner, project_id, region, head_sg_id, cluster_id_token) -> str:
+def _deploy_head_instance(
+    spinner, project_id, region, head_sg_id, cluster_id_token, account_name
+) -> str:
     spinner.text = "Deploying burla-main-service instance ... "
     spinner.start()
 
@@ -715,6 +722,7 @@ def _deploy_head_instance(spinner, project_id, region, head_sg_id, cluster_id_to
         image,
         urlparse(dashboard_url).hostname,
         cluster_id_token,
+        account_name,
     )
     if existing:
         head_id = existing["InstanceId"]

--- a/client/src/burla/_local_head.py
+++ b/client/src/burla/_local_head.py
@@ -9,6 +9,7 @@ and carry none of their own, so the only permissions needed are "can boot
 VMs". `burla deploy` remains the upgrade path to an always-on, shared head VM.
 """
 
+import configparser
 import json
 import os
 import platform
@@ -100,6 +101,31 @@ def detect_cloud() -> tuple[str, str, str | None]:
         or "us-east-1"
     )
     return "aws", f"aws-{result.stdout.strip()}", region
+
+
+def _aws_account_name(account_id: str) -> str:
+    result = subprocess.run(
+        [
+            "aws",
+            "account",
+            "get-account-information",
+            "--query",
+            "AccountName",
+            "--output",
+            "text",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip() not in ("", "None"):
+        return result.stdout.strip()
+
+    config = configparser.ConfigParser()
+    config.read(Path.home() / ".aws" / "config")
+    for section in config.sections():
+        if config[section].get("sso_account_id") == account_id:
+            return section.removeprefix("profile ")
+    return account_id
 
 
 def _gcp_ownership_payload() -> dict:
@@ -450,6 +476,11 @@ def ensure_local_head() -> str:
         "IN_CLIENT_HOSTED_MODE": "True",
         "PROJECT_ID": project_id,
         "CLOUD_PROVIDER": cloud,
+        "CLOUD_ACCOUNT_NAME": (
+            _aws_account_name(project_id.removeprefix("aws-"))
+            if cloud == "aws"
+            else project_id
+        ),
         "CLUSTER_ID_TOKEN": cluster_token,
         "BURLA_BACKEND_URL": _BURLA_BACKEND_URL,
         "BURLA_RELAY_HOST": RELAY_HOST,

--- a/main_service/frontend/src/contexts/SettingsContext.tsx
+++ b/main_service/frontend/src/contexts/SettingsContext.tsx
@@ -17,6 +17,7 @@ const defaultSettings: SettingsData = {
     users: [],
     burlaVersion: " :( ",
     googleCloudProjectId: " :) ",
+    cloudAccountName: " :) ",
     cloudProvider: "gcp",
 };
 

--- a/main_service/frontend/src/pages/Settings.tsx
+++ b/main_service/frontend/src/pages/Settings.tsx
@@ -153,7 +153,7 @@ const SettingsPage = () => {
   const cloudLabel = isAws ? "AWS" : "GCP";
   const resourceLabel = isAws ? "Account" : "Project";
   const resourceId = isAws
-    ? (settings.googleCloudProjectId ?? "").replace(/^aws-/, "")
+    ? settings.cloudAccountName
     : settings.googleCloudProjectId;
 
   const content = (() => {

--- a/main_service/frontend/src/types/coreTypes.ts
+++ b/main_service/frontend/src/types/coreTypes.ts
@@ -118,6 +118,7 @@ export interface Settings {
   gcpRegion?: string;
   burlaVersion?: string;
   googleCloudProjectId?: string;
+  cloudAccountName?: string;
   cloudProvider?: string;
 }
 

--- a/main_service/src/main_service/__init__.py
+++ b/main_service/src/main_service/__init__.py
@@ -77,6 +77,7 @@ def _resolve_project_id() -> str:
 
 
 PROJECT_ID = _resolve_project_id()
+CLOUD_ACCOUNT_NAME = os.environ.get("CLOUD_ACCOUNT_NAME", PROJECT_ID)
 
 
 def relay_fqdn(instance_name: str) -> str:

--- a/main_service/src/main_service/endpoints/settings.py
+++ b/main_service/src/main_service/endpoints/settings.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 
 from main_service import (
     PROJECT_ID,
+    CLOUD_ACCOUNT_NAME,
     CLOUD_PROVIDER,
     CLUSTER_ID_TOKEN,
     CURRENT_BURLA_VERSION,
@@ -40,6 +41,7 @@ def get_settings(request: Request):
         "users": user_emails,
         "burlaVersion": CURRENT_BURLA_VERSION,
         "googleCloudProjectId": PROJECT_ID,
+        "cloudAccountName": CLOUD_ACCOUNT_NAME,
         "cloudProvider": CLOUD_PROVIDER,
         "filesystemEnabled": bool(config_dict.get("gcs_bucket_name")),
     }

--- a/main_service/src/main_service/static/index.html
+++ b/main_service/src/main_service/static/index.html
@@ -10,7 +10,7 @@
         />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="apple-touch-icon" href="/favicon.png" />
-      <script type="module" crossorigin src="/assets/index-CSWWesNm.js"></script>
+      <script type="module" crossorigin src="/assets/index-DW89nNoC.js"></script>
       <link rel="stylesheet" crossorigin href="/assets/index-Behn-Mzj.css">
     </head>
 


### PR DESCRIPTION
## Summary
- resolve AWS AccountName using `account:GetAccountInformation`
- fall back to the matching configured SSO profile when that permission is unavailable
- pass the name into both client-hosted and deployed heads
- display the name in settings while retaining the internal numeric cluster ID only in backend state

## Test plan
- [x] live AWS API resolves `burla-test`
- [x] deployed-head startup commands include CLOUD_ACCOUNT_NAME
- [x] Python compile, frontend ESLint, production build
- [x] `make test-unit` (54 passed)
- [x] browser QA on Vite and the running bundled dashboard: `AWS · Account burla-test`