### PR TITLE
Separate internal development from production

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ results = remote_parallel_map(my_function, list(range(1000)))
 
 The first `remote_parallel_map` call starts Burla's cluster coordinator on your
 machine automatically. The VMs carry no credentials and shut themselves down
-when idle. Run `burla dashboard` at any time to open that same local coordinator,
-boot machines manually, watch jobs, or change machine types.
+when idle. Run `burla dashboard` at any time to run that local coordinator in
+the foreground, stream its server logs, and open the dashboard. Press Ctrl-C to
+stop it.
 
 **Deploying for a team (optional):** `burla deploy` moves the coordinator and dashboard onto a small always-on VM so teammates can share one cluster. This is the only step that requires elevated permissions (service-account and IAM setup); the exact list is in the [CLI reference](https://docs.burla.dev/cli-reference). After deploying, teammates connect with `burla login`.
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -1,5 +1,9 @@
 import json
 import os
+import shlex
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -8,11 +12,47 @@ from platformdirs import user_config_dir
 
 # needed so main_service can associate a client version with a request
 __version__ = "1.6.1"
-_BURLA_BACKEND_URL = os.environ.get(
-    "BURLA_BACKEND_URL", "https://backend.burla.dev"
-).rstrip("/")
 
-_appdata_dir = Path(user_config_dir(appname="burla", appauthor="burla"))
+_SOURCE_ROOT = Path(__file__).resolve().parents[3]
+_IN_SOURCE_CHECKOUT = (
+    (_SOURCE_ROOT / ".git").exists()
+    and (_SOURCE_ROOT / "client" / "pyproject.toml").exists()
+)
+_BURLA_ENVIRONMENT = os.environ.get("BURLA_ENVIRONMENT", "production").lower()
+if _BURLA_ENVIRONMENT not in {"production", "test"}:
+    raise ValueError("BURLA_ENVIRONMENT must be `production` or `test`.")
+if _BURLA_ENVIRONMENT == "test" and not _IN_SOURCE_CHECKOUT:
+    raise RuntimeError(
+        "Burla's internal test environment is only available from an editable "
+        "source checkout."
+    )
+
+_BURLA_APP_NAME = "burla-test" if _BURLA_ENVIRONMENT == "test" else "burla"
+_DEFAULT_BACKEND_URL = (
+    "https://test.backend.burla.dev"
+    if _BURLA_ENVIRONMENT == "test"
+    else "https://backend.burla.dev"
+)
+_DEFAULT_RELAY_HOST = (
+    "relay.test-clusters.burla.dev"
+    if _BURLA_ENVIRONMENT == "test"
+    else "relay.burla.dev"
+)
+_DEFAULT_NODE_SOURCE_REF = "dev" if _BURLA_ENVIRONMENT == "test" else __version__
+_BURLA_BACKEND_URL = os.environ.get(
+    "BURLA_BACKEND_URL", _DEFAULT_BACKEND_URL
+).rstrip("/")
+if _BURLA_BACKEND_URL != "https://backend.burla.dev" and not _IN_SOURCE_CHECKOUT:
+    raise RuntimeError(
+        "Non-production Burla backends are only available from an editable "
+        "source checkout."
+    )
+_BURLA_RELAY_HOST = os.environ.get("BURLA_RELAY_HOST", _DEFAULT_RELAY_HOST)
+_BURLA_NODE_SOURCE_REF = os.environ.get(
+    "BURLA_NODE_SOURCE_REF", _DEFAULT_NODE_SOURCE_REF
+)
+
+_appdata_dir = Path(user_config_dir(appname=_BURLA_APP_NAME, appauthor="burla"))
 CONFIG_PATH = _appdata_dir / Path("burla_credentials.json")
 SETTINGS_PATH = _appdata_dir / Path("config.json")
 
@@ -44,11 +84,15 @@ def set_config(key: str, value: str) -> str:
 
 
 def get_config(key: str = None):
-    config = {"cloud": get_cloud()}
+    config = {
+        "cloud": get_cloud(),
+        "environment": _BURLA_ENVIRONMENT,
+        "backend": _BURLA_BACKEND_URL,
+    }
     if key is None:
         return config
     if key not in config:
-        raise ValueError("The only supported config key is `cloud`.")
+        raise ValueError(f"Unknown config key: {key}")
     return config[key]
 
 
@@ -120,19 +164,112 @@ def version():
 
 
 def dashboard():
-    """Open the Burla dashboard, hosted on this machine.
+    """Run the Burla dashboard on this machine.
 
-    Starts the cluster head locally if it isn't already running - from there
-    you can boot nodes, watch jobs, and change settings. No deployment or
-    special cloud permissions needed (only permission to boot VMs).
+    Runs the cluster head in this terminal and opens it in your browser. From
+    there you can boot nodes, watch jobs, and change settings. Press Ctrl-C to
+    stop it.
     """
     import webbrowser
 
-    from burla._local_head import ensure_local_head
+    from burla._local_head import run_local_head_foreground
 
-    url = ensure_local_head()
-    print(f"Burla dashboard is running at {url}")
-    webbrowser.open(url)
+    def open_dashboard(url: str):
+        print(f"Burla dashboard is running at {url}")
+        print("Press Ctrl-C to stop it.")
+        webbrowser.open(url)
+
+    run_local_head_foreground(on_ready=open_dashboard)
+
+
+def _configure_test_shell_prompt(
+    shell: str, environment: dict[str, str], startup_dir: Path
+) -> list[str]:
+    """Give the child shell a visible test prompt without changing dotfiles."""
+    shell_name = Path(shell).name
+    burla_bin_dir = str(Path(sys.executable).parent)
+    burla_bin_dir_quoted = shlex.quote(burla_bin_dir)
+    environment["PATH"] = (
+        f"{burla_bin_dir}{os.pathsep}{environment.get('PATH', '')}"
+    )
+    if shell_name == "zsh":
+        original_zdotdir = Path(
+            environment.get("ZDOTDIR")
+            or environment.get("HOME")
+            or str(Path.home())
+        ).expanduser()
+        startup_dir_quoted = shlex.quote(str(startup_dir))
+        original_zdotdir_quoted = shlex.quote(str(original_zdotdir))
+
+        for filename in (".zshenv", ".zshrc"):
+            original_file = original_zdotdir / filename
+            source_original = ""
+            if original_file.exists():
+                source_original = (
+                    f"export ZDOTDIR={original_zdotdir_quoted}\n"
+                    f"source {shlex.quote(str(original_file))}\n"
+                    f"export ZDOTDIR={startup_dir_quoted}\n"
+                )
+            (startup_dir / filename).write_text(source_original)
+
+        with (startup_dir / ".zshrc").open("a") as zshrc:
+            zshrc.write(
+                f"\nexport PATH={burla_bin_dir_quoted}:$PATH\n"
+                "rehash\n"
+                "autoload -Uz add-zsh-hook\n"
+                "_burla_test_prompt() {\n"
+                '  if [[ "$PROMPT" != *"[burla test]"* ]]; then\n'
+                "    PROMPT='%F{yellow}%B[burla test]%b%f '$PROMPT\n"
+                "  fi\n"
+                "}\n"
+                "add-zsh-hook precmd _burla_test_prompt\n"
+                "_burla_test_prompt\n"
+            )
+        environment["ZDOTDIR"] = str(startup_dir)
+        return [shell, "-i"]
+
+    if shell_name == "bash":
+        original_bashrc = Path(environment.get("HOME") or str(Path.home())) / ".bashrc"
+        bashrc = startup_dir / "bashrc"
+        source_original = (
+            f"source {shlex.quote(str(original_bashrc))}\n"
+            if original_bashrc.exists()
+            else ""
+        )
+        bashrc.write_text(
+            source_original
+            + f"export PATH={burla_bin_dir_quoted}:$PATH\n"
+            + "PS1='\\[\\e[33;1m\\][burla test]\\[\\e[0m\\] '$PS1\n"
+        )
+        return [shell, "--rcfile", str(bashrc), "-i"]
+
+    environment["PS1"] = f"[burla test] {environment.get('PS1', '')}"
+    return [shell, "-i"]
+
+
+def test_shell():
+    """Enter Burla's isolated internal test environment. Type `exit` to leave."""
+    if not _IN_SOURCE_CHECKOUT:
+        raise RuntimeError("Test mode requires an editable Burla source checkout.")
+
+    environment = dict(os.environ)
+    environment["BURLA_ENVIRONMENT"] = "test"
+    for name in (
+        "BURLA_BACKEND_URL",
+        "BURLA_RELAY_HOST",
+        "BURLA_RELAY_SERVER_ADDR",
+        "BURLA_RELAY_SERVER_PORT",
+        "BURLA_NODE_SOURCE_REF",
+        "BURLA_CLUSTER_DASHBOARD_URL",
+    ):
+        environment.pop(name, None)
+
+    shell = environment.get("SHELL", "/bin/zsh")
+    with tempfile.TemporaryDirectory(prefix="burla-test-shell-") as temp_dir:
+        command = _configure_test_shell_prompt(shell, environment, Path(temp_dir))
+        result = subprocess.run(command, cwd=_SOURCE_ROOT, env=environment)
+    if result.returncode:
+        raise SystemExit(result.returncode)
 
 
 def install(cloud: str = "gcp"):
@@ -143,17 +280,18 @@ def install(cloud: str = "gcp"):
 
 
 def init_cli():
-    Fire(
-        {
-            "login": login,
-            "deploy": deploy,
-            "dashboard": dashboard,
-            "config": {
-                "set": set_config,
-                "get": get_config,
-            },
-            "install": install,
-            "--version": version,
-            "-v": version,
-        }
-    )
+    commands = {
+        "login": login,
+        "deploy": deploy,
+        "dashboard": dashboard,
+        "config": {
+            "set": set_config,
+            "get": get_config,
+        },
+        "install": install,
+        "--version": version,
+        "-v": version,
+    }
+    if _IN_SOURCE_CHECKOUT:
+        commands["test-shell"] = test_shell
+    Fire(commands)

--- a/client/src/burla/_deploy.py
+++ b/client/src/burla/_deploy.py
@@ -12,7 +12,12 @@ from urllib.parse import urlparse
 
 from yaspin import yaspin
 
-from burla import _BURLA_BACKEND_URL, __version__
+from burla import (
+    _BURLA_BACKEND_URL,
+    _BURLA_NODE_SOURCE_REF,
+    _BURLA_RELAY_HOST,
+    __version__,
+)
 from burla._helpers import run_command, VerboseCalledProcessError
 from burla._reporting import log_telemetry
 
@@ -23,7 +28,7 @@ HEAD_ZONE = "us-central1-a"
 
 # All cluster traffic flows through Burla's frp relay: nodes + head dial out
 # to it, so no inbound firewall rules are ever needed in the user's project.
-RELAY_HOST = os.environ.get("BURLA_RELAY_HOST", "relay.burla.dev").strip().lower()
+RELAY_HOST = _BURLA_RELAY_HOST.strip().lower()
 RELAY_SERVER_ADDR = os.environ.get("BURLA_RELAY_SERVER_ADDR", RELAY_HOST)
 RELAY_SERVER_PORT = os.environ.get("BURLA_RELAY_SERVER_PORT", "7000")
 FRP_VERSION = "0.70.1"
@@ -119,7 +124,7 @@ def _head_startup_script(
     image: str,
     dashboard_hostname: str,
 ) -> str:
-    node_source_ref = os.environ.get("BURLA_NODE_SOURCE_REF", __version__)
+    node_source_ref = _BURLA_NODE_SOURCE_REF
     relay_subdomain = f"head--{project_id}"
     caddy_config = f"""{dashboard_hostname} {{
   reverse_proxy burla-main-service:5001

--- a/client/src/burla/_deploy_aws.py
+++ b/client/src/burla/_deploy_aws.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 
 import requests
 
-from burla import _BURLA_BACKEND_URL, __version__
+from burla import _BURLA_BACKEND_URL, _BURLA_NODE_SOURCE_REF, __version__
 from burla._helpers import run_command, VerboseCalledProcessError
 from burla._deploy import RELAY_HOST, RELAY_SERVER_ADDR, RELAY_SERVER_PORT, FRP_VERSION
 from burla._reporting import log_telemetry
@@ -47,7 +47,7 @@ def _head_setup_commands(
     cluster_id_token: str,
     account_name: str,
 ) -> list[str]:
-    node_source_ref = os.environ.get("BURLA_NODE_SOURCE_REF", __version__)
+    node_source_ref = _BURLA_NODE_SOURCE_REF
     relay_subdomain = f"head--{project_id}"
     registry = image.split("/", 1)[0]
     registry_login_commands = []

--- a/client/src/burla/_local_head.py
+++ b/client/src/burla/_local_head.py
@@ -1,12 +1,13 @@
 """
 Client-hosted mode: runs main_service on this machine instead of a head VM.
 
-This is the default way Burla runs. `remote_parallel_map` (or `burla
-dashboard`) starts main_service as a detached subprocess using the code
-vendored inside this package, plus an frpc tunnel so node VMs can reach it
-through the relay. Node VMs are booted with the user's own cloud credentials
-and carry none of their own, so the only permissions needed are "can boot
-VMs". `burla deploy` remains the upgrade path to an always-on, shared head VM.
+This is the default way Burla runs. `remote_parallel_map` starts main_service
+as a detached subprocess using the code vendored inside this package. The
+explicit `burla dashboard` command runs that same service in the foreground.
+Both modes also start an frpc tunnel so node VMs can reach the head through the
+relay. Node VMs are booted with the user's own cloud credentials and carry none
+of their own, so the only permissions needed are "can boot VMs". `burla deploy`
+remains the upgrade path to an always-on, shared head VM.
 """
 
 import configparser
@@ -20,6 +21,7 @@ import sys
 import tarfile
 import tempfile
 import zipfile
+from collections.abc import Callable
 from pathlib import Path
 from time import sleep, time
 from uuid import uuid4
@@ -27,16 +29,24 @@ from uuid import uuid4
 import requests
 from platformdirs import user_data_dir
 
-from burla import _BURLA_BACKEND_URL, __version__
+from burla import (
+    _BURLA_APP_NAME,
+    _BURLA_BACKEND_URL,
+    _BURLA_NODE_SOURCE_REF,
+    _BURLA_RELAY_HOST,
+    __version__,
+)
 
-RELAY_HOST = os.environ.get("BURLA_RELAY_HOST", "relay.burla.dev").strip().lower()
+RELAY_HOST = _BURLA_RELAY_HOST.strip().lower()
 RELAY_SERVER_ADDR = os.environ.get("BURLA_RELAY_SERVER_ADDR", RELAY_HOST)
 RELAY_SERVER_PORT = os.environ.get("BURLA_RELAY_SERVER_PORT", "7000")
 FRP_VERSION = "0.70.1"
 
 PREFERRED_HEAD_PORT = 5001  # the browser login flow redirects to localhost:5001
 
-STATE_ROOT = Path(user_data_dir(appname="burla", appauthor="burla")) / "clusters"
+STATE_ROOT = (
+    Path(user_data_dir(appname=_BURLA_APP_NAME, appauthor="burla")) / "clusters"
+)
 
 
 class LocalHeadError(Exception):
@@ -434,7 +444,21 @@ def _prepare_aws(project_id: str, aws_region: str):
 
 
 def ensure_local_head() -> str:
-    """Starts (or reuses) the client-hosted main_service and returns its URL."""
+    """Starts (or reuses) a detached main_service and returns its URL."""
+    return _run_local_head(detached=True)
+
+
+def run_local_head_foreground(
+    on_ready: Callable[[str], None] | None = None,
+) -> None:
+    """Run main_service attached to this terminal until it exits or Ctrl-C."""
+    _run_local_head(detached=False, on_ready=on_ready)
+
+
+def _run_local_head(
+    detached: bool,
+    on_ready: Callable[[str], None] | None = None,
+) -> str:
     cloud, project_id, aws_region = detect_cloud()
 
     state_dir = _state_dir(project_id)
@@ -445,7 +469,12 @@ def ensure_local_head() -> str:
 
     url = head_state.get("url")
     saved_token = read_saved_cluster_token(project_id)
-    if url and saved_token and _head_matches(url, project_id, saved_token):
+    if (
+        detached
+        and url
+        and saved_token
+        and _head_matches(url, project_id, saved_token)
+    ):
         if not _pid_alive(head_state.get("frpc_pid")):
             _respawn_frpc(state_dir, head_state)
         return url
@@ -486,6 +515,7 @@ def ensure_local_head() -> str:
         "BURLA_RELAY_HOST": RELAY_HOST,
         "BURLA_RELAY_SERVER_ADDR": RELAY_SERVER_ADDR,
         "BURLA_RELAY_SERVER_PORT": str(RELAY_SERVER_PORT),
+        "BURLA_NODE_SOURCE_REF": _BURLA_NODE_SOURCE_REF,
         "MAIN_SERVICE_URL_FOR_NODES": f"https://{subdomain}.{RELAY_HOST}",
         "PORT": str(head_port),
         "INTERNAL_TLS_PORT": str(tls_port),
@@ -506,24 +536,11 @@ def ensure_local_head() -> str:
             f"{extra_pythonpath}{os.pathsep}{existing}" if existing else extra_pythonpath
         )
 
-    head_log = open(state_dir / "head.log", "ab")
-    head_process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "main_service:app",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(head_port),
-            "--timeout-keep-alive",
-            "600",
-        ],
-        env=environment,
-        stdout=head_log,
-        stderr=head_log,
-        start_new_session=True,
+    head_process = _spawn_head(
+        state_dir=state_dir,
+        head_port=head_port,
+        environment=environment,
+        detached=detached,
     )
 
     # Written before the readiness wait so a failed boot never leaks the
@@ -538,24 +555,129 @@ def ensure_local_head() -> str:
     }
     head_state_path.write_text(json.dumps(head_state))
 
-    start = time()
-    while time() - start < 90:
-        if _head_matches(url, project_id, cluster_token):
-            break
-        if head_process.poll() is not None:
-            log_tail = (state_dir / "head.log").read_text()[-3000:]
-            raise LocalHeadError(f"Burla's local service failed to start:\n{log_tail}")
-        sleep(0.5)
-    else:
-        raise LocalHeadError(
-            f"Burla's local service never became ready (see {state_dir / 'head.log'})."
+    if detached:
+        _wait_for_head_ready(
+            head_process, url, project_id, cluster_token, state_dir, detached=True
         )
+        _respawn_frpc(state_dir, head_state, cluster_token=cluster_token)
+        return url
 
-    _respawn_frpc(state_dir, head_state, cluster_token=cluster_token)
+    frpc_process = None
+    try:
+        _wait_for_head_ready(
+            head_process, url, project_id, cluster_token, state_dir, detached=False
+        )
+        frpc_process = _respawn_frpc(
+            state_dir, head_state, cluster_token=cluster_token
+        )
+        if on_ready:
+            on_ready(url)
+        return_code = head_process.wait()
+        if return_code != 0:
+            raise LocalHeadError(
+                f"Burla's local service exited with status {return_code}."
+            )
+    except KeyboardInterrupt:
+        return url
+    finally:
+        _stop_process(head_process)
+        if frpc_process is not None:
+            _stop_process(frpc_process)
+        _clear_process_state(
+            head_state_path,
+            head_process.pid,
+            frpc_process.pid if frpc_process is not None else None,
+        )
     return url
 
 
-def _respawn_frpc(state_dir: Path, head_state: dict, cluster_token: str = None):
+def _wait_for_head_ready(
+    head_process: subprocess.Popen,
+    url: str,
+    project_id: str,
+    cluster_token: str,
+    state_dir: Path,
+    detached: bool,
+):
+    start = time()
+    while time() - start < 90:
+        if _head_matches(url, project_id, cluster_token):
+            return
+        if head_process.poll() is not None:
+            if detached:
+                log_tail = (state_dir / "head.log").read_text()[-3000:]
+                raise LocalHeadError(
+                    f"Burla's local service failed to start:\n{log_tail}"
+                )
+            raise LocalHeadError("Burla's local service failed to start.")
+        sleep(0.5)
+
+    message = "Burla's local service never became ready"
+    if detached:
+        message += f" (see {state_dir / 'head.log'})."
+    else:
+        message += "."
+    raise LocalHeadError(message)
+
+
+def _spawn_head(
+    state_dir: Path,
+    head_port: int,
+    environment: dict[str, str],
+    detached: bool,
+) -> subprocess.Popen:
+    command = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "main_service:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(head_port),
+        "--timeout-keep-alive",
+        "600",
+    ]
+    if not detached:
+        return subprocess.Popen(command, env=environment)
+
+    with open(state_dir / "head.log", "ab") as head_log:
+        return subprocess.Popen(
+            command,
+            env=environment,
+            stdout=head_log,
+            stderr=head_log,
+            start_new_session=True,
+        )
+
+
+def _stop_process(process: subprocess.Popen):
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def _clear_process_state(
+    head_state_path: Path, head_pid: int, frpc_pid: int | None
+):
+    if not head_state_path.exists():
+        return
+    head_state = json.loads(head_state_path.read_text())
+    if head_state.get("head_pid") == head_pid:
+        head_state.pop("head_pid")
+    if frpc_pid is not None and head_state.get("frpc_pid") == frpc_pid:
+        head_state.pop("frpc_pid")
+    head_state_path.write_text(json.dumps(head_state))
+
+
+def _respawn_frpc(
+    state_dir: Path, head_state: dict, cluster_token: str = None
+) -> subprocess.Popen:
     cluster_token = cluster_token or read_saved_cluster_token(head_state["project_id"])
     frpc_binary = ensure_frpc_binary()
     config_path = _write_frpc_config(
@@ -574,3 +696,4 @@ def _respawn_frpc(state_dir: Path, head_state: dict, cluster_token: str = None):
     )
     head_state["frpc_pid"] = frpc_process.pid
     (state_dir / "head.json").write_text(json.dumps(head_state))
+    return frpc_process

--- a/client/tests/README.md
+++ b/client/tests/README.md
@@ -21,6 +21,25 @@ Four tiers:
 
 Nothing runs in GitHub Actions.
 
+#### Internal test environment on a laptop
+
+From a source checkout, enter the isolated test shell with:
+
+```
+make test-shell
+```
+
+Inside that shell, ordinary commands such as `burla dashboard` and notebook
+launches use the test backend, test relay, and the `dev` source ref. Test
+credentials and local-head data are stored separately from production. No
+separate `burla login` is required: Burla bootstraps the isolated profile from
+your cloud credentials. Type `exit` to leave the shell; the parent terminal
+remains in production mode.
+
+This source-only command is a developer convenience, not a security boundary.
+The test backend must independently restrict authentication to approved internal
+identities.
+
 #### Running on a dev VM (humans)
 
 Follow the ephemeral dev-VM workflow (see [`.cursor/skills/burla-ephemeral-dev-vm/SKILL.md`](../../.cursor/skills/burla-ephemeral-dev-vm/SKILL.md)):

--- a/makefile
+++ b/makefile
@@ -15,7 +15,11 @@ define UV_ZSH_ENV
 	ZDOTDIR=$$tmp_dir uv run --project $(PROJECT_ABS) --group $(2) zsh -i
 endef
 
-.PHONY: 3.11-dev 3.12-dev 3.13-dev 3.14-dev 3.11-jupyter 3.12-jupyter 3.13-jupyter 3.14-jupyter
+.PHONY: 3.11-dev 3.12-dev 3.13-dev 3.14-dev 3.11-jupyter 3.12-jupyter 3.13-jupyter 3.14-jupyter test-shell
+
+test-shell:
+	uv sync --project $(PROJECT_ABS) --group dev >/dev/null 2>&1
+	uv run --project $(PROJECT_ABS) --group dev burla test-shell
 
 3.11-dev:
 	$(call UV_ZSH_ENV,3.11,dev)


### PR DESCRIPTION
## Summary
- add a source-only test shell with isolated backend, relay, credentials, and local-head state
- run explicit dashboard sessions in the foreground and keep production defaults unchanged
- make test nodes use the long-lived `dev` branch

## Test plan
- [x] `make test-unit` (54 passed)
- [x] enter and exit `make test-shell`; confirm test backend and `dev` source ref
- [x] confirm normal imports retain the production backend and version source ref