### PR TITLE
Fix development isolation and dashboard reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ results = remote_parallel_map(my_function, list(range(1000)))
 
 The first `remote_parallel_map` call starts Burla's cluster coordinator on your
 machine automatically. The VMs carry no credentials and shut themselves down
-when idle. Run `burla dashboard` at any time to run that local coordinator in
-the foreground, stream its server logs, and open the dashboard. Press Ctrl-C to
-stop it.
+when idle. Run `burla dashboard` to open that coordinator without restarting it.
+If none is running, the command starts one in the foreground and streams its
+logs until you press Ctrl-C.
 
 **Deploying for a team (optional):** `burla deploy` moves the coordinator and dashboard onto a small always-on VM so teammates can share one cluster. This is the only step that requires elevated permissions (service-account and IAM setup); the exact list is in the [CLI reference](https://docs.burla.dev/cli-reference). After deploying, teammates connect with `burla login`.
 

--- a/client/src/burla/__init__.py
+++ b/client/src/burla/__init__.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -164,22 +165,22 @@ def version():
 
 
 def dashboard():
-    """Run the Burla dashboard on this machine.
+    """Open the Burla dashboard hosted on this machine.
 
-    Runs the cluster head in this terminal and opens it in your browser. From
-    there you can boot nodes, watch jobs, and change settings. Press Ctrl-C to
-    stop it.
+    Reuses a healthy cluster head without restarting it. If none is running,
+    starts one in this terminal until Ctrl-C.
     """
     import webbrowser
 
-    from burla._local_head import run_local_head_foreground
+    from burla._local_head import run_local_head_for_dashboard
 
-    def open_dashboard(url: str):
+    def open_dashboard(url: str, is_foreground: bool):
         print(f"Burla dashboard is running at {url}")
-        print("Press Ctrl-C to stop it.")
+        if is_foreground:
+            print("Press Ctrl-C to stop it.")
         webbrowser.open(url)
 
-    run_local_head_foreground(on_ready=open_dashboard)
+    run_local_head_for_dashboard(on_ready=open_dashboard)
 
 
 def _configure_test_shell_prompt(
@@ -264,7 +265,9 @@ def test_shell():
     ):
         environment.pop(name, None)
 
-    shell = environment.get("SHELL", "/bin/zsh")
+    shell = environment.get("SHELL") or shutil.which("zsh") or shutil.which("bash")
+    if shell is None:
+        raise RuntimeError("Test shell requires zsh or bash when SHELL is unset.")
     with tempfile.TemporaryDirectory(prefix="burla-test-shell-") as temp_dir:
         command = _configure_test_shell_prompt(shell, environment, Path(temp_dir))
         result = subprocess.run(command, cwd=_SOURCE_ROOT, env=environment)
@@ -282,16 +285,17 @@ def install(cloud: str = "gcp"):
 def init_cli():
     commands = {
         "login": login,
-        "deploy": deploy,
         "dashboard": dashboard,
         "config": {
             "set": set_config,
             "get": get_config,
         },
-        "install": install,
         "--version": version,
         "-v": version,
     }
+    if _BURLA_ENVIRONMENT == "production":
+        commands["deploy"] = deploy
+        commands["install"] = install
     if _IN_SOURCE_CHECKOUT:
         commands["test-shell"] = test_shell
     Fire(commands)

--- a/client/src/burla/_deploy.py
+++ b/client/src/burla/_deploy.py
@@ -14,6 +14,7 @@ from yaspin import yaspin
 
 from burla import (
     _BURLA_BACKEND_URL,
+    _BURLA_ENVIRONMENT,
     _BURLA_NODE_SOURCE_REF,
     _BURLA_RELAY_HOST,
     __version__,
@@ -240,6 +241,9 @@ def deploy(cloud: str = "gcp"):
       Run: `gcloud config set project <new-project-id>` to change your default project.
     - `burla deploy --cloud=aws` deploys into your current default AWS account/region.
     """
+    if _BURLA_ENVIRONMENT != "production":
+        raise RuntimeError("Deployment is only available in production mode.")
+
     try:
         with yaspin() as spinner:
             if cloud == "aws":

--- a/client/src/burla/_local_head.py
+++ b/client/src/burla/_local_head.py
@@ -3,11 +3,12 @@ Client-hosted mode: runs main_service on this machine instead of a head VM.
 
 This is the default way Burla runs. `remote_parallel_map` starts main_service
 as a detached subprocess using the code vendored inside this package. The
-explicit `burla dashboard` command runs that same service in the foreground.
-Both modes also start an frpc tunnel so node VMs can reach the head through the
-relay. Node VMs are booted with the user's own cloud credentials and carry none
-of their own, so the only permissions needed are "can boot VMs". `burla deploy`
-remains the upgrade path to an always-on, shared head VM.
+explicit `burla dashboard` command reuses that service when healthy or runs it
+in the foreground. Both modes also start an frpc tunnel so node VMs can reach
+the head through the relay. Node VMs are booted with the user's own cloud
+credentials and carry none of their own, so the only permissions needed are
+"can boot VMs". `burla deploy` remains the upgrade path to an always-on, shared
+head VM.
 """
 
 import configparser
@@ -448,16 +449,16 @@ def ensure_local_head() -> str:
     return _run_local_head(detached=True)
 
 
-def run_local_head_foreground(
-    on_ready: Callable[[str], None] | None = None,
+def run_local_head_for_dashboard(
+    on_ready: Callable[[str, bool], None] | None = None,
 ) -> None:
-    """Run main_service attached to this terminal until it exits or Ctrl-C."""
+    """Reuse a healthy head or run one here until it exits or Ctrl-C."""
     _run_local_head(detached=False, on_ready=on_ready)
 
 
 def _run_local_head(
     detached: bool,
-    on_ready: Callable[[str], None] | None = None,
+    on_ready: Callable[[str, bool], None] | None = None,
 ) -> str:
     cloud, project_id, aws_region = detect_cloud()
 
@@ -469,14 +470,11 @@ def _run_local_head(
 
     url = head_state.get("url")
     saved_token = read_saved_cluster_token(project_id)
-    if (
-        detached
-        and url
-        and saved_token
-        and _head_matches(url, project_id, saved_token)
-    ):
+    if url and saved_token and _head_matches(url, project_id, saved_token):
         if not _pid_alive(head_state.get("frpc_pid")):
             _respawn_frpc(state_dir, head_state)
+        if on_ready:
+            on_ready(url, False)
         return url
 
     cluster_token = get_or_register_cluster_token(cloud, project_id, aws_region)
@@ -571,7 +569,7 @@ def _run_local_head(
             state_dir, head_state, cluster_token=cluster_token
         )
         if on_ready:
-            on_ready(url)
+            on_ready(url, True)
         return_code = head_process.wait()
         if return_code != 0:
             raise LocalHeadError(
@@ -665,8 +663,6 @@ def _stop_process(process: subprocess.Popen):
 def _clear_process_state(
     head_state_path: Path, head_pid: int, frpc_pid: int | None
 ):
-    if not head_state_path.exists():
-        return
     head_state = json.loads(head_state_path.read_text())
     if head_state.get("head_pid") == head_pid:
         head_state.pop("head_pid")

--- a/makefile
+++ b/makefile
@@ -18,7 +18,6 @@ endef
 .PHONY: 3.11-dev 3.12-dev 3.13-dev 3.14-dev 3.11-jupyter 3.12-jupyter 3.13-jupyter 3.14-jupyter test-shell
 
 test-shell:
-	uv sync --project $(PROJECT_ABS) --group dev >/dev/null 2>&1
 	uv run --project $(PROJECT_ABS) --group dev burla test-shell
 
 3.11-dev:


### PR DESCRIPTION
## Summary
- reuse a healthy local coordinator when opening the dashboard instead of terminating it
- hide and block deployment commands in the isolated test environment
- remove the shell-path assumption, redundant dependency sync, and speculative state guard

## Test plan
- [x] `make test-unit` (54 passed)
- [x] run `make test-shell` with `SHELL` unset and confirm test backend plus `dev` source ref
- [x] confirm test-mode help omits deployment commands and direct deployment raises before cloud access
- [x] compile client sources and run `git diff --check`